### PR TITLE
Rename native library and re-case "Spokestack"

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,18 @@ mvn checkstyle:check
 ```
 
 ### Release
+Ensure that your Bintray credentials are in your user Maven `settings.xml`:
+
+```xml
+<servers>
+    <server>
+        <id>bintray-spokestack-io.spokestack</id>
+        <username>username</username>
+        <password>bintray_api_key</password>
+    </server>
+</servers>
+```
+
 On a non-master branch, remove the -SNAPSHOT suffix from the version in `pom.xml`, then run the
 following command. This will deploy the package to Bintray and JCenter.
 

--- a/jni/Dev.mk
+++ b/jni/Dev.mk
@@ -4,15 +4,15 @@ CFLAGS = -shared -Wall -O3 -fpic \
          -I$(JAVA_HOME)/include/$(shell uname | tr A-Z a-z)
 OUTDIR = ../target
 
-all: $(OUTDIR)/libspokestack.jnilib
+all: $(OUTDIR)/libspokestack-android.jnilib
 
 clean:
-	$(RM) $(OUTDIR)/libspokestack.jnilib
-	$(RM) $(OUTDIR)/libspokestack.so
+	$(RM) $(OUTDIR)/libspokestack-android.jnilib
+	$(RM) $(OUTDIR)/libspokestack-android.so
 
 rebuild: clean all
 
-$(OUTDIR)/libspokestack.so: \
+$(OUTDIR)/libspokestack-android.so: \
 	agc.cpp \
 	vad.cpp \
 	ans.cpp \

--- a/src/main/java/io/spokestack/spokestack/OnSpeechEventListener.java
+++ b/src/main/java/io/spokestack/spokestack/OnSpeechEventListener.java
@@ -3,7 +3,7 @@ package io.spokestack.spokestack;
 /**
  * speech event callback interface.
  *
- * This is the primary event interface in SpokeStack. The speech pipeline
+ * This is the primary event interface in Spokestack. The speech pipeline
  * routes events/errors asynchronously through it as they occur.
  */
 public interface OnSpeechEventListener {

--- a/src/main/java/io/spokestack/spokestack/SpeechContext.java
+++ b/src/main/java/io/spokestack/spokestack/SpeechContext.java
@@ -6,7 +6,7 @@ import java.util.ArrayList;
 import java.nio.ByteBuffer;
 
 /**
- * SpokeStack speech recognition context
+ * Spokestack speech recognition context
  *
  * <p>
  * This class maintains global state for the speech pipeline, allowing

--- a/src/main/java/io/spokestack/spokestack/SpeechInput.java
+++ b/src/main/java/io/spokestack/spokestack/SpeechInput.java
@@ -6,7 +6,7 @@ import java.nio.ByteBuffer;
  * speech input interface.
  *
  * <p>
- * This is the audio input interface to the SpokeStack framework. Implementors
+ * This is the audio input interface to the Spokestack framework. Implementors
  * must fill the specified audio frame buffer to capacity, based on the
  * configured sample size and frame size.
  * </p>

--- a/src/main/java/io/spokestack/spokestack/SpeechPipeline.java
+++ b/src/main/java/io/spokestack/spokestack/SpeechPipeline.java
@@ -7,10 +7,10 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 /**
- * SpokeStack speech pipeline.
+ * Spokestack speech pipeline.
  *
  * <p>
- * This is the primary client entry point to the SpokeStack framework. It
+ * This is the primary client entry point to the Spokestack framework. It
  * dynamically binds to configured components that implement the pipeline
  * interfaces for reading audio frames and performing speech recognition tasks.
  * </p>

--- a/src/main/java/io/spokestack/spokestack/microsoft/BingSpeechRecognizer.java
+++ b/src/main/java/io/spokestack/spokestack/microsoft/BingSpeechRecognizer.java
@@ -55,7 +55,7 @@ public final class BingSpeechRecognizer implements SpeechProcessor {
 
     /**
      * initializes a new recognizer instance.
-     * @param speechConfig SpokeStack speech configuration
+     * @param speechConfig Spokestack speech configuration
      * @throws Exception on error
      */
     public BingSpeechRecognizer(SpeechConfig speechConfig) throws Exception {
@@ -64,7 +64,7 @@ public final class BingSpeechRecognizer implements SpeechProcessor {
 
     /**
      * initializes a new recognizer instance, useful for testing.
-     * @param speechConfig SpokeStack speech configuration
+     * @param speechConfig Spokestack speech configuration
      * @param builder      speech client builder
      * @throws Exception on error
      */

--- a/src/main/java/io/spokestack/spokestack/package-info.java
+++ b/src/main/java/io/spokestack/spokestack/package-info.java
@@ -1,5 +1,5 @@
 /**
- * The SpokeStack package contains the core classes that implement the speech
+ * The Spokestack package contains the core classes that implement the speech
  * recognition pipeline.
  */
 package io.spokestack.spokestack;

--- a/src/main/java/io/spokestack/spokestack/webrtc/AcousticNoiseSuppressor.java
+++ b/src/main/java/io/spokestack/spokestack/webrtc/AcousticNoiseSuppressor.java
@@ -126,7 +126,7 @@ public class AcousticNoiseSuppressor implements SpeechProcessor {
     // native interface
     //-----------------------------------------------------------------------
     static {
-        System.loadLibrary("spokestack");
+        System.loadLibrary("spokestack-android");
     }
 
     native long create(int rate, int policy);

--- a/src/main/java/io/spokestack/spokestack/webrtc/AutomaticGainControl.java
+++ b/src/main/java/io/spokestack/spokestack/webrtc/AutomaticGainControl.java
@@ -146,7 +146,7 @@ public class AutomaticGainControl implements SpeechProcessor {
     // native interface
     //-----------------------------------------------------------------------
     static {
-        System.loadLibrary("spokestack");
+        System.loadLibrary("spokestack-android");
     }
 
     native long create(

--- a/src/main/java/io/spokestack/spokestack/webrtc/VoiceActivityDetector.java
+++ b/src/main/java/io/spokestack/spokestack/webrtc/VoiceActivityDetector.java
@@ -167,7 +167,7 @@ public class VoiceActivityDetector implements SpeechProcessor {
     // native interface
     //-----------------------------------------------------------------------
     static {
-        System.loadLibrary("spokestack");
+        System.loadLibrary("spokestack-android");
     }
 
     native long create(int mode);


### PR DESCRIPTION
The `android-native-dependencies` plugin does not allow you to rename the native binaries it downloads; when it copies them to `jniLibs`, it names them with the artifactId. Thus, in order to keep the `spokestack-android` name and have things resolve correctly, we have to name the compiled native libraries to match.