### PR TITLE
Fix: Remove dependency on Math.floorMod from 1.8

### DIFF
--- a/src/main/java/io/spokestack/spokestack/wakeword/RingBuffer.java
+++ b/src/main/java/io/spokestack/spokestack/wakeword/RingBuffer.java
@@ -107,6 +107,10 @@ final class RingBuffer {
     }
 
     private int pos(int x) {
-        return Math.floorMod(x, this.data.length);
+        int mod = x % this.data.length;
+        if (x < 0) {
+            return -mod;
+        }
+        return mod;
     }
 }

--- a/src/main/java/io/spokestack/spokestack/wakeword/RingBuffer.java
+++ b/src/main/java/io/spokestack/spokestack/wakeword/RingBuffer.java
@@ -107,9 +107,12 @@ final class RingBuffer {
     }
 
     private int pos(int x) {
+        // equivalent to Math.floorMod;
+        // we only have to check x's sign because
+        // this.data.length is guaranteed to be positive
         int mod = x % this.data.length;
-        if (x < 0) {
-            return -mod;
+        if (x < 0 && mod != 0) {
+            return mod + this.data.length;
         }
         return mod;
     }

--- a/src/main/java/io/spokestack/spokestack/wakeword/RingBuffer.java
+++ b/src/main/java/io/spokestack/spokestack/wakeword/RingBuffer.java
@@ -107,12 +107,13 @@ final class RingBuffer {
     }
 
     private int pos(int x) {
-        // equivalent to Math.floorMod;
-        // we only have to check x's sign because
-        // this.data.length is guaranteed to be positive
+        // Math.floorMod from OpenJDK;
+        // reproduced here because relying on the JDK
+        // method unnecessarily limits Android API compatibility
+        // to level 26 or newer
         int mod = x % this.data.length;
-        if (x < 0 && mod != 0) {
-            return mod + this.data.length;
+        if ((mod ^ this.data.length) < 0 && mod != 0) {
+            mod += this.data.length;
         }
         return mod;
     }

--- a/src/test/java/io/spokestack/spokestack/wakeword/RingBufferTest.java
+++ b/src/test/java/io/spokestack/spokestack/wakeword/RingBufferTest.java
@@ -98,14 +98,6 @@ public class RingBufferTest {
         for (int i = 0; i < buffer.capacity(); i++)
             buffer.write(i + 1);
 
-        // negative seek wraps around --
-        // position 5 in the buffer contains 0;
-        // we'll end up at position 5, which contains 5
-        buffer.seek(-2);
-        assertEquals(buffer.read(), buffer.capacity());
-
-        buffer.rewind();
-
         buffer.seek(1);
         for (int i = 1; i < buffer.capacity(); i++)
             assertEquals(buffer.read(), i + 1);
@@ -114,6 +106,11 @@ public class RingBufferTest {
         buffer.seek(buffer.capacity() - 1);
         for (int i = buffer.capacity() - 1; i < buffer.capacity(); i++)
             assertEquals(buffer.read(), i + 1);
+
+        // negative seek wraps around --
+        // the read head here starts at position 5 and will end up at 4
+        buffer.seek(-7);
+        assertEquals(buffer.read(), buffer.capacity());
     }
 
     @Test

--- a/src/test/java/io/spokestack/spokestack/wakeword/RingBufferTest.java
+++ b/src/test/java/io/spokestack/spokestack/wakeword/RingBufferTest.java
@@ -103,6 +103,12 @@ public class RingBufferTest {
             assertEquals(buffer.read(), i + 1);
         buffer.rewind();
 
+        // negative seek wraps around
+        buffer.seek(-2);
+        assertEquals(buffer.read(), buffer.capacity() - 2);
+
+        buffer.rewind();
+
         buffer.seek(buffer.capacity() - 1);
         for (int i = buffer.capacity() - 1; i < buffer.capacity(); i++)
             assertEquals(buffer.read(), i + 1);

--- a/src/test/java/io/spokestack/spokestack/wakeword/RingBufferTest.java
+++ b/src/test/java/io/spokestack/spokestack/wakeword/RingBufferTest.java
@@ -98,15 +98,17 @@ public class RingBufferTest {
         for (int i = 0; i < buffer.capacity(); i++)
             buffer.write(i + 1);
 
+        // negative seek wraps around --
+        // position 5 in the buffer contains 0;
+        // we'll end up at position 5, which contains 5
+        buffer.seek(-2);
+        assertEquals(buffer.read(), buffer.capacity());
+
+        buffer.rewind();
+
         buffer.seek(1);
         for (int i = 1; i < buffer.capacity(); i++)
             assertEquals(buffer.read(), i + 1);
-        buffer.rewind();
-
-        // negative seek wraps around
-        buffer.seek(-2);
-        assertEquals(buffer.read(), buffer.capacity() - 2);
-
         buffer.rewind();
 
         buffer.seek(buffer.capacity() - 1);


### PR DESCRIPTION
This update allows dependent apps to target Android API
versions lower than 26 that do not have access to all
methods from JDK 1.8.