### PR TITLE
Store Android Context directly in TTSManager

### DIFF
--- a/src/main/java/io/spokestack/spokestack/SpeechOutput.java
+++ b/src/main/java/io/spokestack/spokestack/SpeechOutput.java
@@ -52,9 +52,9 @@ public abstract class SpeechOutput extends TTSComponent
     public abstract void audioReceived(AudioResponse response);
 
     /**
-     * Sets the output's application context.
+     * Sets the output's Android context.
      *
-     * @param appContext The application context.
+     * @param androidContext The Android context.
      */
-    public abstract void setAppContext(Context appContext);
+    public abstract void setAndroidContext(Context androidContext);
 }

--- a/src/test/java/io/spokestack/spokestack/tts/SpokestackTTSOutputTest.java
+++ b/src/test/java/io/spokestack/spokestack/tts/SpokestackTTSOutputTest.java
@@ -74,7 +74,7 @@ public class SpokestackTTSOutputTest {
     public void testResourceManagement() {
         SpokestackTTSOutput ttsOutput =
               new SpokestackTTSOutput(null, factory);
-        ttsOutput.setAppContext(mockContext);
+        ttsOutput.setAndroidContext(mockContext);
         lifecycleRegistry.addObserver(ttsOutput);
         ttsOutput.prepare();
         lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
@@ -197,7 +197,6 @@ public class SpokestackTTSOutputTest {
               .when(ttsOutput).createMediaSource(any());
         doReturn(AudioManager.AUDIOFOCUS_REQUEST_GRANTED)
               .when(ttsOutput).requestFocus();
-        ttsOutput.setAppContext(mockContext);
         return ttsOutput;
     }
 

--- a/src/test/java/io/spokestack/spokestack/tts/TTSManagerTest.java
+++ b/src/test/java/io/spokestack/spokestack/tts/TTSManagerTest.java
@@ -42,13 +42,13 @@ public class TTSManagerTest implements TTSListener {
     public void testBuilder() throws Exception {
         // invalid TTS service
         assertThrows(ClassNotFoundException.class,
-              () -> new TTSManager.Builder(context)
+              () -> new TTSManager.Builder()
                     .setTTSServiceClass("invalid")
                     .build());
 
         // invalid output component
         assertThrows(ClassNotFoundException.class,
-              () -> new TTSManager.Builder(context)
+              () -> new TTSManager.Builder()
                     .setTTSServiceClass("io.spokestack.spokestack.tts.SpokestackTTSService")
                     .setProperty("spokestack-key", "test")
                     .setProperty("spokestack-secret", "test")
@@ -60,11 +60,12 @@ public class TTSManagerTest implements TTSListener {
         LifecycleRegistry lifecycleRegistry =
               new LifecycleRegistry(mock(LifecycleOwner.class));
 
-        TTSManager manager = new TTSManager.Builder(context)
+        TTSManager manager = new TTSManager.Builder()
               .setTTSServiceClass("io.spokestack.spokestack.tts.TTSManagerTest$Input")
               .setOutputClass("io.spokestack.spokestack.tts.TTSManagerTest$Output")
               .setProperty("spokestack-key", "test")
               .setConfig(new SpeechConfig())
+              .setAndroidContext(context)
               .setLifecycle(lifecycleRegistry)
               .addTTSListener(this)
               .build();
@@ -138,8 +139,8 @@ public class TTSManagerTest implements TTSListener {
     public static class Output extends SpeechOutput
           implements DefaultLifecycleObserver {
 
-        public Output(SpeechConfig config) {
-        }
+        @SuppressWarnings("unused")
+        public Output(SpeechConfig config) { }
 
         @Override
         public void onResume(@NotNull LifecycleOwner owner) {
@@ -155,8 +156,7 @@ public class TTSManagerTest implements TTSListener {
         }
 
         @Override
-        public void setAppContext(Context appContext) {
-        }
+        public void setAndroidContext(Context appContext) { }
 
         @Override
         public void close() {


### PR DESCRIPTION
In keeping with the principle of leaving POJOs out of the configuration object, this PR moves the Android context for the media player into `TTSManager`.