### PR TITLE
Change references from client "key" to "ID"

### DIFF
--- a/src/main/java/io/spokestack/spokestack/tts/SpokestackTTSClient.java
+++ b/src/main/java/io/spokestack/spokestack/tts/SpokestackTTSClient.java
@@ -40,8 +40,8 @@ public final class SpokestackTTSClient {
     private final OkHttpClient httpClient;
     private TTSCallback ttsCallback;
     private final Gson gson;
-    private String ttsClientId;
-    private String ttsClientSecret;
+    private String ttsApiId;
+    private String ttsApiSecret;
 
     /**
      * Create a new Spokestack TTS client. This client should be created once
@@ -61,7 +61,7 @@ public final class SpokestackTTSClient {
     }
 
     /**
-     * Create a new Spokestack TTS client with an API key and a provided HTTP
+     * Create a new Spokestack TTS client with an API ID and a provided HTTP
      * client. Used for testing.
      *
      * @param callback The callback object used to deliver an audio URL when it
@@ -94,15 +94,15 @@ public final class SpokestackTTSClient {
     }
 
     /**
-     * Set the API key used for synthesis requests.
+     * Set the API ID used for synthesis requests.
      *
-     * @param clientId     The client ID used for synthesis requests.
-     * @param clientSecret The client secret used to sign synthesis
-     *                     requests.
+     * @param apiId     The ID used for synthesis requests.
+     * @param apiSecret The secret key used to sign synthesis
+     *                  requests.
      */
-    public void setCredentials(String clientId, String clientSecret) {
-        this.ttsClientId = clientId;
-        this.ttsClientSecret = clientSecret;
+    public void setCredentials(String apiId, String apiSecret) {
+        this.ttsApiId = apiId;
+        this.ttsApiSecret = apiSecret;
     }
 
     /**
@@ -143,12 +143,12 @@ public final class SpokestackTTSClient {
     private void postSpeech(Map<String, String> headers,
                             String queryString,
                             Map<String, String> variables) {
-        if (this.ttsClientId == null) {
-            ttsCallback.onError("client key not provided");
+        if (this.ttsApiId == null) {
+            ttsCallback.onError("API ID not provided");
             return;
         }
-        if (this.ttsClientSecret == null) {
-            ttsCallback.onError("client secret not provided");
+        if (this.ttsApiSecret == null) {
+            ttsCallback.onError("API secret not provided");
             return;
         }
         if (this.ttsUrl == null) {
@@ -178,7 +178,7 @@ public final class SpokestackTTSClient {
               .url(ttsUrl)
               .header("Content-Type", "application/json")
               .header("Authorization",
-                    "Spokestack " + ttsClientId + ":" + authHeader)
+                    "Spokestack " + ttsApiId + ":" + authHeader)
               .post(postBody)
               .build();
 
@@ -190,7 +190,7 @@ public final class SpokestackTTSClient {
         try {
             Mac hmacAlgo = Mac.getInstance(HMAC_TYPE);
             byte[] keyBytes =
-                  this.ttsClientSecret.getBytes(StandardCharsets.UTF_8);
+                  this.ttsApiSecret.getBytes(StandardCharsets.UTF_8);
             SecretKeySpec keySpec = new SecretKeySpec(keyBytes, HMAC_TYPE);
             hmacAlgo.init(keySpec);
             byte[] macData = hmacAlgo.doFinal(
@@ -199,7 +199,7 @@ public final class SpokestackTTSClient {
         } catch (NoSuchAlgorithmException e) {
             this.ttsCallback.onError("Invalid HMAC algorithm");
         } catch (InvalidKeyException e) {
-            this.ttsCallback.onError("Invalid client key");
+            this.ttsCallback.onError("Invalid API secret");
         }
 
         return base64Signature;

--- a/src/main/java/io/spokestack/spokestack/tts/SpokestackTTSClient.java
+++ b/src/main/java/io/spokestack/spokestack/tts/SpokestackTTSClient.java
@@ -40,7 +40,7 @@ public final class SpokestackTTSClient {
     private final OkHttpClient httpClient;
     private TTSCallback ttsCallback;
     private final Gson gson;
-    private String ttsClientKey;
+    private String ttsClientId;
     private String ttsClientSecret;
 
     /**
@@ -96,12 +96,12 @@ public final class SpokestackTTSClient {
     /**
      * Set the API key used for synthesis requests.
      *
-     * @param apiKey       The API key to use for synthesis requests.
-     * @param clientSecret The client secret used to authorize synthesis
+     * @param clientId     The client ID used for synthesis requests.
+     * @param clientSecret The client secret used to sign synthesis
      *                     requests.
      */
-    public void setCredentials(String apiKey, String clientSecret) {
-        this.ttsClientKey = apiKey;
+    public void setCredentials(String clientId, String clientSecret) {
+        this.ttsClientId = clientId;
         this.ttsClientSecret = clientSecret;
     }
 
@@ -143,7 +143,7 @@ public final class SpokestackTTSClient {
     private void postSpeech(Map<String, String> headers,
                             String queryString,
                             Map<String, String> variables) {
-        if (this.ttsClientKey == null) {
+        if (this.ttsClientId == null) {
             ttsCallback.onError("client key not provided");
             return;
         }
@@ -178,7 +178,7 @@ public final class SpokestackTTSClient {
               .url(ttsUrl)
               .header("Content-Type", "application/json")
               .header("Authorization",
-                    "Spokestack " + ttsClientKey + ":" + authHeader)
+                    "Spokestack " + ttsClientId + ":" + authHeader)
               .post(postBody)
               .build();
 

--- a/src/main/java/io/spokestack/spokestack/tts/SpokestackTTSService.java
+++ b/src/main/java/io/spokestack/spokestack/tts/SpokestackTTSService.java
@@ -17,8 +17,12 @@ import java.io.IOException;
  * </p>
  * <ul>
  *     <li>
- *         <b>spokestack-key</b> (string): The API key used for synthesis
- *         requests.
+ *         <b>spokestack-id</b> (string, required): The client ID used for
+ *         synthesis requests.
+ *     </li>
+ *     <li>
+ *         <b>spokestack-secret</b> (string, required): The client secret used
+ *         to sign synthesis requests.
  *     </li>
  *     <li>
  *         <b>spokestack-url</b> (string): The URL used for synthesis
@@ -61,9 +65,9 @@ public final class SpokestackTTSService extends TTSService {
     }
 
     private void configure(SpeechConfig config) {
-        String apiKey = config.getString("spokestack-key");
+        String clientId = config.getString("spokestack-id");
         String clientSecret = config.getString("spokestack-secret");
-        this.client.setCredentials(apiKey, clientSecret);
+        this.client.setCredentials(clientId, clientSecret);
         String ttsUrl = config.getString("spokestack-url", null);
         if (ttsUrl != null) {
             this.client.setTtsUrl(ttsUrl);

--- a/src/main/java/io/spokestack/spokestack/tts/SpokestackTTSService.java
+++ b/src/main/java/io/spokestack/spokestack/tts/SpokestackTTSService.java
@@ -65,9 +65,9 @@ public final class SpokestackTTSService extends TTSService {
     }
 
     private void configure(SpeechConfig config) {
-        String clientId = config.getString("spokestack-id");
-        String clientSecret = config.getString("spokestack-secret");
-        this.client.setCredentials(clientId, clientSecret);
+        String apiId = config.getString("spokestack-id");
+        String apiSecret = config.getString("spokestack-secret");
+        this.client.setCredentials(apiId, apiSecret);
         String ttsUrl = config.getString("spokestack-url", null);
         if (ttsUrl != null) {
             this.client.setTtsUrl(ttsUrl);

--- a/src/main/java/io/spokestack/spokestack/tts/TTSCallback.java
+++ b/src/main/java/io/spokestack/spokestack/tts/TTSCallback.java
@@ -28,7 +28,7 @@ public abstract class TTSCallback implements Callback {
           throws IOException {
         if (!httpResponse.isSuccessful()) {
             if (httpResponse.code() == 403) {
-                onError("Invalid API key");
+                onError("Invalid API secret");
             } else {
                 onError("Synthesis error: HTTP " + httpResponse.code());
             }

--- a/src/main/java/io/spokestack/spokestack/tts/TTSManager.java
+++ b/src/main/java/io/spokestack/spokestack/tts/TTSManager.java
@@ -32,7 +32,11 @@ import java.util.List;
  * TTSManager ttsManager = new TTSManager.Builder()
  *     .setTTSServiceClass("io.spokestack.spokestack.tts.SpokestackTTSService")
  *     .setOutputClass("io.spokestack.spokestack.tts.SpokestackTTSOutput")
- *     .setProperty("spokestack-key", "f854fbf30a5f40c189ecb1b38bc78059")
+ *     .setProperty("spokestack-id", "f0bc990c-e9db-4a0c-a2b1-6a6395a3d97e")
+ *     .setProperty(
+ *         "spokestack-secret",
+ *         "5BD5483F573D691A15CFA493C1782F451D4BD666E39A9E7B2EBE287E6A72C6B6")
+ *     .setAndroidContext(getApplicationContext())
  *     .setLifecycle(getLifecycle())
  *     .build();
  * }

--- a/src/test/java/io/spokestack/spokestack/tts/SpokestackTTSClientTest.java
+++ b/src/test/java/io/spokestack/spokestack/tts/SpokestackTTSClientTest.java
@@ -67,8 +67,8 @@ public class SpokestackTTSClientTest {
 
     @Test
     public void testConfig() throws Exception {
-        // no api key
-        TestCallback callback = new TestCallback("client key not provided");
+        // no API id
+        TestCallback callback = new TestCallback("API ID not provided");
         SpokestackTTSClient client =
               new SpokestackTTSClient(callback, httpClient);
 
@@ -76,17 +76,17 @@ public class SpokestackTTSClientTest {
         client.synthesize(request);
         assertTrue(callback.errorReceived);
 
-        // no client secret
-        callback = new TestCallback("client secret not provided");
+        // no API secret
+        callback = new TestCallback("API secret not provided");
         client = new SpokestackTTSClient(callback, httpClient);
         client.setCredentials("valid", null);
 
         client.synthesize(request);
         assertTrue(callback.errorReceived);
 
-        // invalid api key
+        // invalid API secret
         CountDownLatch latch = new CountDownLatch(1);
-        callback = new TestCallback("Invalid API key", latch);
+        callback = new TestCallback("Invalid API secret", latch);
         client = new SpokestackTTSClient(callback, httpClient);
         client.setCredentials("invalid", "invalider");
         client.synthesize(request);
@@ -97,7 +97,7 @@ public class SpokestackTTSClientTest {
         latch = new CountDownLatch(1);
         callback = new TestCallback("Synthesis error: HTTP 419", latch);
         client = new SpokestackTTSClient(callback, httpClient);
-        client.setCredentials("key", "secret");
+        client.setCredentials("id", "secret");
         SynthesisRequest invalidSSML = new SynthesisRequest.Builder("just text")
               .withMode(SynthesisRequest.Mode.SSML).build();
         client.synthesize(invalidSSML);
@@ -108,7 +108,7 @@ public class SpokestackTTSClientTest {
         latch = new CountDownLatch(1);
         callback = new TestCallback("TTS URL not provided", latch);
         client = new SpokestackTTSClient(callback, httpClient);
-        client.setCredentials("key", "secret");
+        client.setCredentials("id", "secret");
         client.setTtsUrl(null);
         client.synthesize(request);
         latch.await(1, TimeUnit.SECONDS);
@@ -120,10 +120,10 @@ public class SpokestackTTSClientTest {
         CountDownLatch latch = new CountDownLatch(1);
         TestCallback callback = new TestCallback(null, latch);
         SpokestackTTSClient client = new SpokestackTTSClient(callback, httpClient);
-        String key = "f0bc990c-e9db-4a0c-a2b1-6a6395a3d97e";
+        String id = "f0bc990c-e9db-4a0c-a2b1-6a6395a3d97e";
         String secret =
               "5BD5483F573D691A15CFA493C1782F451D4BD666E39A9E7B2EBE287E6A72C6B6";
-        client.setCredentials(key, secret);
+        client.setCredentials(id, secret);
 
         String body = "{\"query\": "
               + "\"query AndroidSynthesize($voice:String!, $text:String!) {"
@@ -140,7 +140,7 @@ public class SpokestackTTSClientTest {
         CountDownLatch latch = new CountDownLatch(1);
         TestCallback callback = new TestCallback(null, latch);
         SpokestackTTSClient client = new SpokestackTTSClient(callback, httpClient);
-        client.setCredentials("key", "secret");
+        client.setCredentials("id", "secret");
 
         SynthesisRequest request = new SynthesisRequest.Builder("text").build();
         client.synthesize(request);
@@ -151,7 +151,7 @@ public class SpokestackTTSClientTest {
         latch = new CountDownLatch(1);
         callback = new TestCallback(null, latch);
         client = new SpokestackTTSClient(callback, httpClient);
-        client.setCredentials("key", "secret");
+        client.setCredentials("id", "secret");
         HashMap<String, String> metadata = new HashMap<>();
         String requestId = "abce153193";
         metadata.put("id", requestId);
@@ -224,7 +224,7 @@ public class SpokestackTTSClientTest {
         public Response intercept(@NotNull Chain chain) throws IOException {
             Request request = chain.request();
 
-            if (hasInvalidKey(request)) {
+            if (hasInvalidId(request)) {
                 return invalidResponse;
             }
             if (hasInvalidBody(request)) {
@@ -253,7 +253,7 @@ public class SpokestackTTSClientTest {
             return builder.build();
         }
 
-        private boolean hasInvalidKey(Request request) {
+        private boolean hasInvalidId(Request request) {
             String authHeader = request.header("Authorization");
             return authHeader != null && authHeader.contains("invalid:");
         }

--- a/src/test/java/io/spokestack/spokestack/tts/SpokestackTTSServiceTest.java
+++ b/src/test/java/io/spokestack/spokestack/tts/SpokestackTTSServiceTest.java
@@ -59,7 +59,7 @@ public class SpokestackTTSServiceTest {
     @Test
     public void testCleanup() {
         SpeechConfig config = new SpeechConfig();
-        config.put("spokestack-key", "test");
+        config.put("spokestack-id", "test");
         config.put("spokestack-secret", "test");
         config.put("spokestack-url", "https://api.spokestack.io");
         SpokestackTTSService ttsService = new SpokestackTTSService(config,
@@ -76,7 +76,7 @@ public class SpokestackTTSServiceTest {
     @Test
     public void testSynthesize() throws InterruptedException {
         SpeechConfig config = new SpeechConfig();
-        config.put("spokestack-key", "test");
+        config.put("spokestack-id", "test");
         config.put("spokestack-secret", "test");
         config.put("spokestack-url", "https://api.spokestack.io");
         SpokestackTTSService ttsService =

--- a/src/test/java/io/spokestack/spokestack/tts/TTSManagerTest.java
+++ b/src/test/java/io/spokestack/spokestack/tts/TTSManagerTest.java
@@ -50,7 +50,7 @@ public class TTSManagerTest implements TTSListener {
         assertThrows(ClassNotFoundException.class,
               () -> new TTSManager.Builder(context)
                     .setTTSServiceClass("io.spokestack.spokestack.tts.SpokestackTTSService")
-                    .setProperty("spokestack-key", "test")
+                    .setProperty("spokestack-id", "test")
                     .setProperty("spokestack-secret", "test")
                     .setOutputClass("invalid")
                     .build());
@@ -63,7 +63,7 @@ public class TTSManagerTest implements TTSListener {
         TTSManager manager = new TTSManager.Builder(context)
               .setTTSServiceClass("io.spokestack.spokestack.tts.TTSManagerTest$Input")
               .setOutputClass("io.spokestack.spokestack.tts.TTSManagerTest$Output")
-              .setProperty("spokestack-key", "test")
+              .setProperty("spokestack-id", "test")
               .setConfig(new SpeechConfig())
               .setLifecycle(lifecycleRegistry)
               .addTTSListener(this)
@@ -115,9 +115,9 @@ public class TTSManagerTest implements TTSListener {
     public static class Input extends TTSService {
 
         public Input(SpeechConfig config) {
-            String key = config.getString("spokestack-key", "default");
+            String key = config.getString("spokestack-id", "default");
             if (!key.equals("default")) {
-                fail("custom key should not be set by tests");
+                fail("custom client ID should not be set by tests");
             }
         }
 


### PR DESCRIPTION
As we discussed, there will be no more talk of keys. I found some credentials-related doc to update while I was renaming, so win-win.