### PR TITLE
Feature: SpeechPipeline.Builder profiles

### DIFF
--- a/src/main/java/io/spokestack/spokestack/PipelineProfile.java
+++ b/src/main/java/io/spokestack/spokestack/PipelineProfile.java
@@ -1,0 +1,26 @@
+package io.spokestack.spokestack;
+
+/**
+ * A pipeline profile encapsulates a series of configuration values tuned for
+ * a specific task to make building a {@link SpeechPipeline} more convenient.
+ *
+ * <p>
+ * Profiles are not authoritative; they act just like calling a series of
+ * methods on a {@link SpeechPipeline.Builder}, and any configuration
+ * properties they set can be overridden by subsequent calls.
+ * </p>
+ *
+ * <p>
+ * Pipeline profiles must not require arguments in their constructors.
+ * </p>
+ */
+public interface PipelineProfile {
+
+    /**
+     * Apply this profile to the pipeline builder.
+     *
+     * @param builder The builder to which the profile should be applied.
+     * @return The modified pipeline builder.
+     */
+    SpeechPipeline.Builder apply(SpeechPipeline.Builder builder);
+}

--- a/src/main/java/io/spokestack/spokestack/Profile.java
+++ b/src/main/java/io/spokestack/spokestack/Profile.java
@@ -1,0 +1,48 @@
+package io.spokestack.spokestack;
+
+/**
+ * Convenience shortcuts to pre-built {@link PipelineProfile}s used to configure
+ * the {@link SpeechPipeline}.
+ */
+public enum Profile {
+    /**
+     * Do not perform wakeword detection.
+     *
+     * @see io.spokestack.spokestack.profile.NoWakeword
+     */
+    WAKEWORD_NONE("io.spokestack.spokestack.profile.NoWakeword"),
+
+    /**
+     * Use TensorFlow Lite models for wakeword detection.
+     *
+     * @see io.spokestack.spokestack.profile.TFLiteWakeword
+     */
+    WAKEWORD_TFLITE("io.spokestack.spokestack.profile.TFLiteWakeword"),
+
+    /**
+     * Use Android's built-in {@code SpeechRecognizer} ASR.
+     *
+     * @see io.spokestack.spokestack.android.AndroidSpeechRecognizer
+     */
+    ASR_ANDROID("io.spokestack.spokestack.profile.AndroidASR"),
+
+    /**
+     * Use Google Speech for ASR.
+     *
+     * @see io.spokestack.spokestack.google.GoogleSpeechRecognizer
+     */
+    ASR_GOOGLE_CLOUD("io.spokestack.spokestack.profile.GoogleSpeechASR");
+
+    private final String className;
+
+    Profile(String c) {
+        this.className = c;
+    }
+
+    /**
+     * @return The name of the class that implements this profile.
+     */
+    public String getClassName() {
+        return this.className;
+    }
+}

--- a/src/main/java/io/spokestack/spokestack/profile/AndroidASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/AndroidASR.java
@@ -1,0 +1,23 @@
+package io.spokestack.spokestack.profile;
+
+import io.spokestack.spokestack.PipelineProfile;
+import io.spokestack.spokestack.SpeechPipeline;
+
+/**
+ * A speech pipeline profile that uses Android's {@code SpeechRecognizer} API
+ * for ASR.
+ *
+ * <p>
+ * Since the configuration properties used by Google Speech are app-specific,
+ * those must be set outside this class.
+ * </p>
+ *
+ * @see io.spokestack.spokestack.google.GoogleSpeechRecognizer
+ */
+public class AndroidASR implements PipelineProfile {
+    @Override
+    public SpeechPipeline.Builder apply(SpeechPipeline.Builder builder) {
+        return builder.addStageClass(
+              "io.spokestack.spokestack.android.AndroidSpeechRecognizer");
+    }
+}

--- a/src/main/java/io/spokestack/spokestack/profile/GoogleSpeechASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/GoogleSpeechASR.java
@@ -1,0 +1,22 @@
+package io.spokestack.spokestack.profile;
+
+import io.spokestack.spokestack.PipelineProfile;
+import io.spokestack.spokestack.SpeechPipeline;
+
+/**
+ * A speech pipeline profile that uses Google Speech for ASR.
+ *
+ * <p>
+ * Since the configuration properties used by Google Speech are app-specific,
+ * those must be set outside this class.
+ * </p>
+ *
+ * @see io.spokestack.spokestack.google.GoogleSpeechRecognizer
+ */
+public class GoogleSpeechASR implements PipelineProfile {
+    @Override
+    public SpeechPipeline.Builder apply(SpeechPipeline.Builder builder) {
+        return builder.addStageClass(
+              "io.spokestack.spokestack.google.GoogleSpeechRecognizer");
+    }
+}

--- a/src/main/java/io/spokestack/spokestack/profile/NoWakeword.java
+++ b/src/main/java/io/spokestack/spokestack/profile/NoWakeword.java
@@ -1,0 +1,20 @@
+package io.spokestack.spokestack.profile;
+
+import io.spokestack.spokestack.PipelineProfile;
+import io.spokestack.spokestack.SpeechPipeline;
+
+/**
+ * A speech pipeline profile that does not perform wakeword detection. This
+ * profile is simply a shortcut for using the device microphone for input and
+ * performs no other configuration.
+ *
+ * @see io.spokestack.spokestack.android.MicrophoneInput
+ */
+public class NoWakeword implements PipelineProfile {
+
+    @Override
+    public SpeechPipeline.Builder apply(SpeechPipeline.Builder builder) {
+        return builder.setInputClass(
+              "io.spokestack.spokestack.android.MicrophoneInput");
+    }
+}

--- a/src/main/java/io/spokestack/spokestack/profile/TFLiteWakeword.java
+++ b/src/main/java/io/spokestack/spokestack/profile/TFLiteWakeword.java
@@ -1,0 +1,40 @@
+package io.spokestack.spokestack.profile;
+
+import io.spokestack.spokestack.PipelineProfile;
+import io.spokestack.spokestack.SpeechPipeline;
+
+/**
+ * A speech pipeline profile that uses the device microphone for input and
+ * TensorFlow Lite models for wakeword detection.
+ *
+ * <p>
+ * When using this profile, setting the paths to the profiles via {@link
+ * SpeechPipeline.Builder#setProperty(String, Object)} and the {@code
+ * wake-detect-path}, {@code wake-encode-path}, and {@code wake-fiter-path} keys
+ * is still required.
+ * </p>
+ *
+ * @see io.spokestack.spokestack.wakeword.WakewordTrigger
+ */
+public class TFLiteWakeword implements PipelineProfile {
+
+    @Override
+    public SpeechPipeline.Builder apply(SpeechPipeline.Builder builder) {
+        builder
+              .setInputClass(
+                    "io.spokestack.spokestack.android.MicrophoneInput")
+              .addStageClass(
+                    "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
+              .addStageClass(
+                    "io.spokestack.spokestack.webrtc.AutomaticGainControl")
+              .addStageClass(
+                    "io.spokestack.spokestack.webrtc.VoiceActivityDetector")
+              .addStageClass(
+                    "io.spokestack.spokestack.wakeword.WakewordTrigger")
+              .setProperty("agc-compression-gain-db", 15)
+              .setProperty("wake-active-min", 2000)
+              .setProperty("pre-emphasis", 0.97);
+
+        return builder;
+    }
+}

--- a/src/main/java/io/spokestack/spokestack/profile/package-info.java
+++ b/src/main/java/io/spokestack/spokestack/profile/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * This package contains pre-built profiles used to configure the speech
+ * pipeline.
+ */
+package io.spokestack.spokestack.profile;


### PR DESCRIPTION
Pipeline profiles enable a cleaner setup for the speech pipeline, allowing a client application to express their intended configuration either with the name of a pre-built profile or the class name of a custom profile instead of a cascade of individual configuration options.

An application can choose to add any properties required by a given component to the pipeline builder directly, or in a more explicit, modular fashion by passing a map to `useProfile`. All profile usage represents simple shortcuts to builder configuration; a property or even input class added to the builder after a profile will override the profile's settings.

I haven't updated the readme here in anticipation of feedback, but I can include such an update in the PR if this design seems reasonable. The updated test provides usage examples, but it looks pretty close to the current pipeline build process.