### PR TITLE
Breaking: Turn activation timeout into a component

### DIFF
--- a/src/main/java/io/spokestack/spokestack/ActivationTimeout.java
+++ b/src/main/java/io/spokestack/spokestack/ActivationTimeout.java
@@ -1,0 +1,84 @@
+package io.spokestack.spokestack;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Speech recognition activation timer.
+ *
+ * <p>
+ * This component manages the timeout for pipeline activation (the period of
+ * time in which the pipeline is actively listening and sending speech through a
+ * speech recognition provider).
+ * </p>
+ *
+ * <p>
+ * The pipeline can be activated via a trigger component or manually; it will
+ * remain active for a minimum amount of time, after which it will be
+ * deactivated when the user stops speaking, or a timeout occurs. Both the
+ * minimum and maximum activation times are configurable, via the following
+ * properties:
+ * </p>
+ *
+ * <ul>
+ *   <li>
+ *      <b>active-min</b> (integer): the minimum length of an
+ *      activation, in milliseconds, used to ignore a VAD deactivation after
+ *      the manual activation
+ *   </li>
+ *   <li>
+ *      <b>active-max</b> (integer): the maximum length of an
+ *      activation, in milliseconds, used to time out the activation
+ *   </li>
+ * </ul>
+ *
+ */
+public final class ActivationTimeout implements SpeechProcessor {
+    private static final int DEFAULT_ACTIVE_MIN = 500;
+    private static final int DEFAULT_ACTIVE_MAX = 5000;
+
+    private final int minActive;
+    private final int maxActive;
+
+    private boolean isSpeech;
+    private int activeLength;
+
+    /**
+     * Constructs a new timeout component.
+     * @param config the pipeline configuration
+     */
+    public ActivationTimeout(SpeechConfig config) {
+        int frameWidth = config.getInteger("frame-width");
+        this.minActive = config .getInteger("active-min", DEFAULT_ACTIVE_MIN)
+              / frameWidth;
+        this.maxActive = config .getInteger("active-max", DEFAULT_ACTIVE_MAX)
+              / frameWidth;
+    }
+
+    @Override
+    public void process(SpeechContext context, ByteBuffer buffer) {
+        boolean vadFall = this.isSpeech && !context.isSpeech();
+        this.isSpeech = context.isSpeech();
+        if (context.isActive() && ++this.activeLength > this.minActive) {
+            if (vadFall || this.activeLength > this.maxActive) {
+                deactivate(context);
+            }
+        }
+    }
+
+    private void deactivate(SpeechContext context) {
+        this.activeLength = 0;
+        context.setActive(false);
+    }
+
+    @Override
+    public void close() {
+        reset();
+    }
+
+    /**
+     * Reset the trigger's activity timer.
+     */
+    public void reset() {
+        this.activeLength = 0;
+    }
+}

--- a/src/main/java/io/spokestack/spokestack/SpeechContext.java
+++ b/src/main/java/io/spokestack/spokestack/SpeechContext.java
@@ -157,6 +157,11 @@ public final class SpeechContext {
      */
     public SpeechContext setActive(boolean value) {
         this.active = value;
+        if (value) {
+            dispatch(Event.ACTIVATE);
+        } else {
+            dispatch(Event.DEACTIVATE);
+        }
         return this;
     }
 

--- a/src/main/java/io/spokestack/spokestack/SpeechContext.java
+++ b/src/main/java/io/spokestack/spokestack/SpeechContext.java
@@ -156,10 +156,11 @@ public final class SpeechContext {
      * @return this
      */
     public SpeechContext setActive(boolean value) {
+        boolean isActive = this.active;
         this.active = value;
-        if (value) {
+        if (value && !isActive) {
             dispatch(Event.ACTIVATE);
-        } else {
+        } else if (!value && isActive) {
             dispatch(Event.DEACTIVATE);
         }
         return this;

--- a/src/main/java/io/spokestack/spokestack/SpeechPipeline.java
+++ b/src/main/java/io/spokestack/spokestack/SpeechPipeline.java
@@ -27,7 +27,8 @@ import java.nio.ByteOrder;
  * {@code
  *  SpeechPipeline pipeline = new SpeechPipeline.Builder()
  *      .setInputClass("io.spokestack.spokestack.android.MicrophoneInput")
- *      .addStageClass("io.spokestack.spokestack.libfvad.VADTrigger")
+ *      .addStageClass("io.spokestack.spokestack.webrtc.VoiceActivityTrigger")
+ *      .addStageClass("io.spokestack.spokestack.ActivationTimeout")
  *      .setProperty("sample-rate", 16000)
  *      .setProperty("frame-width", 20)
  *      .setProperty("buffer-width", 300)
@@ -115,10 +116,20 @@ public final class SpeechPipeline implements AutoCloseable {
     }
 
     /**
-     * @return true if the pipeline is listening, false otherwise.
+     * @return true if the pipeline has been started, false otherwise.
      */
     public boolean isRunning() {
         return this.running;
+    }
+
+    /** manually activate the speech pipeline. */
+    public void activate() {
+        this.context.setActive(true);
+    }
+
+    /** manually deactivate the speech pipeline. */
+    public void deactivate() {
+        this.context.setActive(false);
     }
 
     /**

--- a/src/main/java/io/spokestack/spokestack/webrtc/VoiceActivityTrigger.java
+++ b/src/main/java/io/spokestack/spokestack/webrtc/VoiceActivityTrigger.java
@@ -42,10 +42,6 @@ public class VoiceActivityTrigger implements SpeechProcessor {
         if (context.isSpeech() != this.isSpeech) {
             if (context.isSpeech()) {
                 context.setActive(true);
-                context.dispatch(SpeechContext.Event.ACTIVATE);
-            } else {
-                context.setActive(false);
-                context.dispatch(SpeechContext.Event.DEACTIVATE);
             }
             this.isSpeech = context.isSpeech();
         }

--- a/src/test/java/io/spokestack/spokestack/ActivationTimeoutTest.java
+++ b/src/test/java/io/spokestack/spokestack/ActivationTimeoutTest.java
@@ -1,0 +1,109 @@
+package io.spokestack.spokestack;
+
+import io.spokestack.spokestack.tensorflow.TensorflowModel;
+import io.spokestack.spokestack.wakeword.WakewordTrigger;
+import io.spokestack.spokestack.wakeword.WakewordTriggerTest;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class ActivationTimeoutTest {
+    private SpeechContext context;
+
+    @Test
+    public void testClose() throws Exception {
+        // verify that close() throws no errors
+        ActivationTimeoutTest.TestEnv env =
+              new ActivationTimeoutTest.TestEnv(testConfig());
+        env.process();
+        env.close();
+    }
+
+    @Test
+    public void testVadDeactivate() throws Exception {
+        // verify deactivation on vad timeout after min activation length
+        ActivationTimeoutTest.TestEnv env =
+              new ActivationTimeoutTest.TestEnv(testConfig());
+
+        env.context.setActive(true);
+        assertEquals(SpeechContext.Event.ACTIVATE, env.event);
+        // reset the event so we can verify nothing gets sent until the
+        // minimum activation time has passed
+        env.event = null;
+
+        env.context.setSpeech(true);
+        env.process();
+        env.process();
+
+        env.context.setSpeech(false);
+        assertNull(env.event);
+
+        env.process();
+        assertEquals(SpeechContext.Event.DEACTIVATE, env.event);
+        assertFalse(env.context.isActive());
+    }
+
+    @Test
+    public void testManualTimeout() throws Exception {
+        // verify manual activation max activation timeout
+        ActivationTimeoutTest.TestEnv env =
+              new ActivationTimeoutTest.TestEnv(testConfig());
+
+        env.context.setActive(true);
+        env.process();
+        env.process();
+        env.process();
+        env.process();
+
+        assertEquals(SpeechContext.Event.DEACTIVATE, env.event);
+        assertFalse(env.context.isActive());
+    }
+
+    private SpeechConfig testConfig() {
+        return new SpeechConfig()
+              .put("sample-rate", 16000)
+              .put("frame-width", 10)
+              .put("active-min", 20)
+              .put("active-max", 30);
+    }
+
+    public class TestEnv implements OnSpeechEventListener {
+        public final ByteBuffer frame;
+        public final SpeechContext context;
+        public final ActivationTimeout timeout;
+        public SpeechContext.Event event;
+
+        public TestEnv(SpeechConfig config) {
+            int sampleRate = config.getInteger("sample-rate");
+            int frameWidth = config.getInteger("frame-width");
+
+            // create the frame buffer and wakeword trigger
+            this.frame = ByteBuffer.allocateDirect(frameWidth * sampleRate / 1000 * 2);
+
+            // create the speech context for processing calls
+            this.context = new SpeechContext(config);
+            context.addOnSpeechEventListener(this);
+
+            this.timeout = new ActivationTimeout(config);
+        }
+
+        public void process() throws Exception {
+            this.timeout.process(this.context, this.frame);
+        }
+
+        public void close() {
+            this.timeout.close();
+        }
+
+        public void onEvent(SpeechContext.Event event, SpeechContext context) {
+            this.event = event;
+        }
+    }
+}

--- a/src/test/java/io/spokestack/spokestack/SpeechContextTest.java
+++ b/src/test/java/io/spokestack/spokestack/SpeechContextTest.java
@@ -202,6 +202,29 @@ public class SpeechContextTest implements OnSpeechEventListener {
         assertEquals("trace", Event.TRACE.toString());
     }
 
+    @Test
+    public void testActivationEvents() {
+        SpeechConfig config = new SpeechConfig();
+        SpeechContext context = new SpeechContext(config);
+
+        // valid listener
+        context.addOnSpeechEventListener(this);
+        context.setActive(true);
+        assertEquals(Event.ACTIVATE, this.event);
+        this.event = null;
+
+        // no event unless the current state changes
+        context.setActive(true);
+        assertNull(this.event);
+
+        context.setActive(false);
+        assertEquals(Event.DEACTIVATE, this.event);
+        this.event = null;
+
+        context.setActive(false);
+        assertNull(this.event);
+    }
+
     public void onEvent(Event event, SpeechContext context) {
         this.event = event;
         this.context = context;

--- a/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
+++ b/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
@@ -141,10 +141,6 @@ public class SpeechPipelineTest implements OnSpeechEventListener {
         Input.stop();
         pipeline.stop();
         assertEquals(SpeechContext.Event.ERROR, this.events.get(0));
-        // more than one error might be sent, but deactivate should
-        // be sent last
-        assertEquals(SpeechContext.Event.DEACTIVATE,
-              this.events.get(this.events.size() - 1));
     }
 
     private void transact() throws Exception {

--- a/src/test/java/io/spokestack/spokestack/wakeword/WakewordTriggerTest.java
+++ b/src/test/java/io/spokestack/spokestack/wakeword/WakewordTriggerTest.java
@@ -135,27 +135,6 @@ public class WakewordTriggerTest {
     }
 
     @Test
-    public void testDetActiveVadDeactivate() throws Exception {
-        // verify deactivation on vad timeout after min activation length
-        TestEnv env = new TestEnv(testConfig());
-
-        env.context.setSpeech(true);
-        env.detect.setOutputs(0);
-        env.process();
-
-        env.detect.setOutputs(1);
-        env.process();
-        env.process();
-
-        env.process();
-        env.process();
-        env.process();
-
-        assertEquals(SpeechContext.Event.DEACTIVATE, env.event);
-        assertFalse(env.context.isActive());
-    }
-
-    @Test
     public void testDetActiveMinDelay() throws Exception {
         // verify no deactivation on vad timeout before min activation length
         TestEnv env = new TestEnv(testConfig());
@@ -175,44 +154,6 @@ public class WakewordTriggerTest {
     }
 
     @Test
-    public void testDetActiveTimeout() throws Exception {
-        // verify max activation timeout
-        TestEnv env = new TestEnv(testConfig());
-
-        env.context.setSpeech(true);
-        env.detect.setOutputs(0);
-        env.process();
-
-        env.detect.setOutputs(1);
-        env.process();
-        env.process();
-        env.process();
-
-        env.context.setSpeech(false);
-        env.process();
-
-        assertEquals(SpeechContext.Event.DEACTIVATE, env.event);
-        assertFalse(env.context.isActive());
-    }
-
-    @Test
-    public void testDetManualVadDeactivate() throws Exception {
-        // verify manual activation followed by vad deactivation
-        TestEnv env = new TestEnv(testConfig());
-
-        env.context.setActive(true);
-        env.context.setSpeech(true);
-        env.process();
-        env.process();
-
-        env.context.setSpeech(false);
-        env.process();
-
-        assertEquals(SpeechContext.Event.DEACTIVATE, env.event);
-        assertFalse(env.context.isActive());
-    }
-
-    @Test
     public void testDetManualMinDelay() throws Exception {
         // verify manual activation remains with no vad activation/deactivation
         TestEnv env = new TestEnv(testConfig());
@@ -223,21 +164,6 @@ public class WakewordTriggerTest {
         env.process();
 
         assertTrue(env.context.isActive());
-    }
-
-    @Test
-    public void testDetManualTimeout() throws Exception {
-        // verify manual activation max activation timeout
-        TestEnv env = new TestEnv(testConfig());
-
-        env.context.setActive(true);
-        env.process();
-        env.process();
-        env.process();
-        env.process();
-
-        assertEquals(SpeechContext.Event.DEACTIVATE, env.event);
-        assertFalse(env.context.isActive());
     }
 
     @Test
@@ -270,9 +196,7 @@ public class WakewordTriggerTest {
             .put("wake-encode-path", "encode-path")
             .put("wake-detect-path", "detect-path")
             .put("wake-encode-length", 1000)
-            .put("wake-encode-width", 128)
-            .put("wake-active-min", 20)
-            .put("wake-active-max", 30);
+            .put("wake-encode-width", 128);
     }
 
     public static class TestModel extends TensorflowModel {

--- a/src/test/java/io/spokestack/spokestack/webrtc/VoiceActivityTriggerTest.java
+++ b/src/test/java/io/spokestack/spokestack/webrtc/VoiceActivityTriggerTest.java
@@ -44,24 +44,6 @@ public class VoiceActivityTriggerTest implements OnSpeechEventListener {
         vad.process(context, sampleBuffer(config));
         assertEquals(SpeechContext.Event.ACTIVATE, this.event);
         assertTrue(context.isActive());
-
-        // continued speech
-        this.event = null;
-        vad.process(context, sampleBuffer(config));
-        assertEquals(null, this.event);
-        assertTrue(context.isActive());
-
-        // silence transition
-        context.setSpeech(false);
-        vad.process(context, sampleBuffer(config));
-        assertEquals(SpeechContext.Event.DEACTIVATE, this.event);
-        assertFalse(context.isActive());
-
-        // continued silence
-        this.event = null;
-        vad.process(context, sampleBuffer(config));
-        assertEquals(null, this.event);
-        assertFalse(context.isActive());
     }
 
     private ByteBuffer sampleBuffer(SpeechConfig config) {


### PR DESCRIPTION
This change decouples pipeline ASR activation from the trigger
stages, enabling a hybrid manual/wakeword activation by adding
a new ActivationTimeout component.

The activation length configuration properties have been
renamed to "active-min" and "active-max" to reflect this
change.

In addition, the pipeline now has public methods to control
speech context activation, and when the speech context is activated
or deactivated, it dispatches the corresponding speech event to
listeners internally.