### PR TITLE
Fix: Simple ProGuard rules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,9 @@
             <version>4.6.0</version>
             <extensions>true</extensions>
             <configuration>
+               <consumerProguardFiles>
+                  <consumerProguardFile>src/main/proguard.txt</consumerProguardFile>
+               </consumerProguardFiles>
                <sdk>
                   <platform>26</platform>
                </sdk>

--- a/src/main/proguard.txt
+++ b/src/main/proguard.txt
@@ -1,0 +1,18 @@
+## Spokestack proguard config
+
+-keep class io.spokestack.** { *; }
+
+-keep public class * {
+    public protected *;
+}
+
+-keepparameternames
+-renamesourcefileattribute SourceFile
+-keepattributes Exceptions,InnerClasses,Signature,Deprecated,
+                SourceFile,LineNumberTable,*Annotation*,EnclosingMethod
+
+-keepclasseswithmembernames,includedescriptorclasses class * {
+    native <methods>;
+}
+
+## end Spokestack proguard config


### PR DESCRIPTION
These rules keep ProGuard from removing Spokestack classes,
which are often loaded dynamically.

Addresses Issue #18.