### PR TITLE
Fix flaky test and coverage

### DIFF
--- a/src/main/java/io/spokestack/spokestack/android/AndroidSpeechRecognizer.java
+++ b/src/main/java/io/spokestack/spokestack/android/AndroidSpeechRecognizer.java
@@ -57,7 +57,7 @@ import java.util.ArrayList;
  * place.
  * </p>
  */
-public final class AndroidSpeechRecognizer implements SpeechProcessor {
+public class AndroidSpeechRecognizer implements SpeechProcessor {
     private boolean streaming;
     private SpeechRecognizer speechRecognizer;
     private TaskHandler taskHandler;
@@ -120,7 +120,7 @@ public final class AndroidSpeechRecognizer implements SpeechProcessor {
         });
     }
 
-    private Intent createRecognitionIntent() {
+    Intent createRecognitionIntent() {
         Intent intent = new Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH);
         intent.putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL,
               RecognizerIntent.LANGUAGE_MODEL_FREE_FORM);

--- a/src/test/java/io/spokestack/spokestack/android/AndroidSpeechRecognizerTest.java
+++ b/src/test/java/io/spokestack/spokestack/android/AndroidSpeechRecognizerTest.java
@@ -23,7 +23,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.powermock.api.mockito.PowerMockito.*;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({SpeechRecognizer.class, AndroidSpeechRecognizer.class, Bundle.class})
+@PrepareForTest({SpeechRecognizer.class, Bundle.class})
 public class AndroidSpeechRecognizerTest {
 
     private ContextWrapper emptyAppContext = mock(ContextWrapper.class);
@@ -70,7 +70,8 @@ public class AndroidSpeechRecognizerTest {
     public void testProcess() {
         SpeechConfig config = new SpeechConfig();
         AndroidSpeechRecognizer speechRecognizer =
-              new AndroidSpeechRecognizer(config, new TaskHandler(false));
+              spy(new AndroidSpeechRecognizer(config, new TaskHandler(false)));
+        doReturn(null).when(speechRecognizer).createRecognitionIntent();
         SpeechContext context = new SpeechContext(config);
         context.setAndroidContext(mockContext);
         EventListener listener = new EventListener();
@@ -93,7 +94,8 @@ public class AndroidSpeechRecognizerTest {
         listener.clear();
         context.setActive(true);
         speechRecognizer =
-              new AndroidSpeechRecognizer(config, new TaskHandler(false));
+              spy(new AndroidSpeechRecognizer(config, new TaskHandler(false)));
+        doReturn(null).when(speechRecognizer).createRecognitionIntent();
         speechRecognizer.process(context, frame);
         assertNull(listener.transcript);
         assertEquals(SpeechRecognizerError.class, listener.error.getClass());

--- a/src/test/java/io/spokestack/spokestack/tts/SpokestackTTSOutputTest.java
+++ b/src/test/java/io/spokestack/spokestack/tts/SpokestackTTSOutputTest.java
@@ -15,6 +15,7 @@ import com.google.android.exoplayer2.source.MediaSource;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -29,8 +30,12 @@ import static org.mockito.Mockito.*;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(ExoPlaybackException.class)
 public class SpokestackTTSOutputTest {
-    private LifecycleRegistry lifecycleRegistry =
-          new LifecycleRegistry(mock(LifecycleOwner.class));
+    @Mock
+    @SuppressWarnings("unused")
+    LifecycleOwner owner;
+
+    @InjectMocks
+    private LifecycleRegistry lifecycleRegistry;
 
     @Mock
     private Context mockContext;


### PR DESCRIPTION
This update fixes a test for TTS output by injecting a mocked object that should never be garbage collected while the test is running (something that would occasionally trip up the test runner
before). It also "improves" test coverage for the Android ASR component by making it non-final and thus removing the need to modify its byte code for testing.