### PR TITLE
Fix: Declare a targetSdkVersion

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-   package="io.spokestack.spokestack">
+          package="io.spokestack.spokestack">
 
-   <uses-permission android:name="android.permission.RECORD_AUDIO" />
-   <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-sdk android:minSdkVersion="8"
+              android:targetSdkVersion="29"/>
 </manifest>


### PR DESCRIPTION
Turns out that if your library doesn't specify a `targetSdkVersion`, Android assumes SDK 1, which results in some extra (suspicious-looking) permissions being requested by default on app install.

API level 8 is specified as the min because that's when the platform `SpeechRecognizer` API was added (not that it'll necessarily be functional on a device that old...).