### PR TITLE
Add tracing for Android speech recognizer events

### DIFF
--- a/src/main/java/io/spokestack/spokestack/android/AndroidSpeechRecognizer.java
+++ b/src/main/java/io/spokestack/spokestack/android/AndroidSpeechRecognizer.java
@@ -172,28 +172,43 @@ public class AndroidSpeechRecognizer implements SpeechProcessor {
             return confidences.length > 0 ? confidences[0] : 0.0f;
         }
 
-        // other methods required by RecognitionListener but useless for our
-        // current purposes
+        @Override
+        public void onReadyForSpeech(Bundle params) {
+            this.context.traceDebug(
+                  "AndroidSpeechRecognizer ready for speech");
+        }
 
         @Override
-        public void onReadyForSpeech(Bundle params) { }
+        public void onBeginningOfSpeech() {
+            this.context.traceDebug("AndroidSpeechRecognizer begin speech");
+        }
 
         @Override
-        public void onBeginningOfSpeech() { }
+        public void onRmsChanged(float rmsdB) {
+            this.context.traceDebug("AndroidSpeechRecognizer RMS %f", rmsdB);
+        }
 
         @Override
-        public void onRmsChanged(float rmsdB) { }
+        public void onBufferReceived(byte[] buffer) {
+            this.context.traceDebug("AndroidSpeechRecognizer buffer received");
+        }
 
         @Override
-        public void onBufferReceived(byte[] buffer) { }
+        public void onEndOfSpeech() {
+            this.context.traceDebug("AndroidSpeechRecognizer end speech");
+        }
 
         @Override
-        public void onEndOfSpeech() { }
+        public void onPartialResults(Bundle partialResults) {
+            String transcript = extractTranscript(partialResults);
+            this.context.traceDebug(
+                  "AndroidSpeechRecognizer partial results: %s", transcript);
+        }
 
         @Override
-        public void onPartialResults(Bundle partialResults) { }
-
-        @Override
-        public void onEvent(int eventType, Bundle params) { }
+        public void onEvent(int eventType, Bundle params) {
+            this.context.traceDebug(
+                  "AndroidSpeechRecognizer event: %d", eventType);
+        }
     }
 }

--- a/src/test/java/io/spokestack/spokestack/android/MockRecognizer.java
+++ b/src/test/java/io/spokestack/spokestack/android/MockRecognizer.java
@@ -46,31 +46,29 @@ public class MockRecognizer {
      */
     @SuppressWarnings("unused")
     public void startListening(Intent recognitionIntent) {
+        Bundle results = mock(Bundle.class);
+        ArrayList<String> nBest =
+              new ArrayList<>( Arrays.asList(TRANSCRIPT, "testy"));
+        when(results
+              .getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION))
+              .thenReturn(nBest);
+        float[] confidences = new float[]{.85f, .15f};
+        when(results
+              .getFloatArray(SpeechRecognizer.CONFIDENCE_SCORES))
+              .thenReturn(confidences);
+
         if (this.isSuccessful) {
-            Bundle results = mock(Bundle.class);
-            ArrayList<String> nBest =
-                  new ArrayList<>( Arrays.asList(TRANSCRIPT, "testy"));
-            when(results
-                  .getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION))
-                  .thenReturn(nBest);
-            float[] confidences = new float[]{.85f, .15f};
-            when(results
-                  .getFloatArray(SpeechRecognizer.CONFIDENCE_SCORES))
-                  .thenReturn(confidences);
             recognitionListener.onResults(results);
         } else {
             recognitionListener.onError(4);
         }
 
-        // this is a terrible thing to do to just improve test coverage for
-        // unimplemented methods, but it will trigger a revisiting of this
-        // test if the methods are implemented in the future
         recognitionListener.onReadyForSpeech(null);
         recognitionListener.onBeginningOfSpeech();
         recognitionListener.onRmsChanged(0);
         recognitionListener.onBufferReceived(new byte[]{});
         recognitionListener.onEndOfSpeech();
-        recognitionListener.onPartialResults(null);
+        recognitionListener.onPartialResults(results);
         recognitionListener.onEvent(0, null);
     }
 }


### PR DESCRIPTION
Not much to see here, but I wanted better visibility into some of these things while troubleshooting with new devices, so I figured I'd just make it formal instead of ad hoc print statements.