### PR TITLE
Bert-based on-device NLU

### DIFF
--- a/src/main/java/io/spokestack/spokestack/nlu/NLUResult.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/NLUResult.java
@@ -9,27 +9,19 @@ import java.util.Map;
  */
 public final class NLUResult {
     private final String intent;
+    private final float confidence;
     private final String utterance;
     private final Map<String, Object> context;
     private final Map<String, Slot> slots;
     private final Throwable error;
 
-    private NLUResult(String builderUtterance, String builderIntent,
-                      Map<String, Slot> builderSlots,
-                      Map<String, Object> builderContext) {
-        this.intent = builderIntent;
-        this.utterance = builderUtterance;
-        this.slots = builderSlots;
-        this.context = builderContext;
-        this.error = null;
-    }
-
-    private NLUResult(String builderUtterance, Throwable builderError) {
-        this.utterance = builderUtterance;
-        this.error = builderError;
-        this.intent = null;
-        this.slots = null;
-        this.context = null;
+    private NLUResult(Builder builder) {
+        this.error = builder.builderError;
+        this.utterance = builder.builderUtterance;
+        this.intent = builder.builderIntent;
+        this.confidence = builder.builderConfidence;
+        this.slots = builder.builderSlots;
+        this.context = builder.builderContext;
     }
 
     /**
@@ -44,6 +36,13 @@ public final class NLUResult {
      */
     public String getIntent() {
         return intent;
+    }
+
+    /**
+     * @return The NLU's confidence in its intent prediction.
+     */
+    public float getConfidence() {
+        return confidence;
     }
 
     /**
@@ -74,6 +73,7 @@ public final class NLUResult {
 
         private String builderUtterance;
         private String builderIntent;
+        private float builderConfidence;
         private Map<String, Slot> builderSlots;
         private Map<String, Object> builderContext;
         private Throwable builderError;
@@ -84,7 +84,8 @@ public final class NLUResult {
          */
         public Builder(String utterance) {
             this.builderUtterance = utterance;
-            this.builderIntent = "";
+            this.builderIntent = null;
+            this.builderConfidence = 0.0f;
             this.builderSlots = new HashMap<>();
             this.builderContext = new HashMap<>();
         }
@@ -106,6 +107,17 @@ public final class NLUResult {
          */
         public Builder withIntent(String intent) {
             this.builderIntent = intent;
+            return this;
+        }
+
+        /**
+         * Set the confidence for the intent classification.
+         * @param confidence The classifier's confidence for its intent
+         *                   prediction.
+         * @return this
+         */
+        public Builder withConfidence(float confidence) {
+            this.builderConfidence = confidence;
             return this;
         }
 
@@ -134,11 +146,7 @@ public final class NLUResult {
          * @return A populated NLU result instance.
          */
         public NLUResult build() {
-            if (builderError != null) {
-                return new NLUResult(builderUtterance, builderError);
-            }
-            return new NLUResult(builderUtterance, builderIntent,
-                  builderSlots, builderContext);
+            return new NLUResult(this);
         }
     }
 }

--- a/src/main/java/io/spokestack/spokestack/nlu/NLUResult.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/NLUResult.java
@@ -73,9 +73,9 @@ public final class NLUResult {
     public static final class Builder {
 
         private String builderUtterance;
-        private String builderIntent = "";
-        private Map<String, Slot> builderSlots = new HashMap<>();
-        private Map<String, Object> builderContext = new HashMap<>();
+        private String builderIntent;
+        private Map<String, Slot> builderSlots;
+        private Map<String, Object> builderContext;
         private Throwable builderError;
 
         /**
@@ -84,6 +84,9 @@ public final class NLUResult {
          */
         public Builder(String utterance) {
             this.builderUtterance = utterance;
+            this.builderIntent = "";
+            this.builderSlots = new HashMap<>();
+            this.builderContext = new HashMap<>();
         }
 
         /**

--- a/src/main/java/io/spokestack/spokestack/nlu/NLUResult.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/NLUResult.java
@@ -1,5 +1,6 @@
 package io.spokestack.spokestack.nlu;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -72,9 +73,9 @@ public final class NLUResult {
     public static final class Builder {
 
         private String builderUtterance;
-        private String builderIntent;
-        private Map<String, Slot> builderSlots;
-        private Map<String, Object> builderContext;
+        private String builderIntent = "";
+        private Map<String, Slot> builderSlots = new HashMap<>();
+        private Map<String, Object> builderContext = new HashMap<>();
         private Throwable builderError;
 
         /**

--- a/src/main/java/io/spokestack/spokestack/nlu/Slot.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/Slot.java
@@ -13,17 +13,20 @@ import java.util.Objects;
  */
 public final class Slot {
     private final String name;
+    private final String rawValue;
     private final Object value;
 
     /**
      * Create a new slot.
      *
      * @param n   The slot's name.
-     * @param val The slot's value.
+     * @param original The slot's original string value.
+     * @param parsed The slot's parsed value.
      */
-    public Slot(String n, Object val) {
+    public Slot(String n, String original, Object parsed) {
         this.name = n;
-        this.value = val;
+        this.rawValue = original;
+        this.value = parsed;
     }
 
     /**
@@ -31,6 +34,21 @@ public final class Slot {
      */
     public String getName() {
         return name;
+    }
+
+    /**
+     * @return The slot's original value in the user utterance, before being
+     * processed by any parsers.
+     */
+    public String getRawValue() {
+        return rawValue;
+    }
+
+    /**
+     * @return The slot's parsed value.
+     */
+    public Object getValue() {
+        return value;
     }
 
     @Override
@@ -43,6 +61,7 @@ public final class Slot {
         }
         Slot slot = (Slot) o;
         return getName().equals(slot.getName())
+              && getRawValue().equals(slot.getRawValue())
               && getValue().equals(slot.getValue());
     }
 
@@ -54,37 +73,10 @@ public final class Slot {
     @Override
     public String toString() {
         return "Slot{"
-              + "name='" + name + '\''
+              + "name=\"" + name
+              + "\", rawValue=" + rawValue
               + ", value=" + value
               + '}';
-    }
-
-    /**
-     * @return The slot's value.
-     */
-    public Object getValue() {
-        return value;
-    }
-
-    /**
-     * Create a typed slot by parsing its value using type information from the
-     * model's metadata.
-     *
-     * @param type  The type of slot to be parsed.
-     * @param name  The slot's name.
-     * @param value The string version of the slot's value to be parsed.
-     * @return A slot with a value parsed using the supplied type information.
-     */
-    public static Slot parse(String type, String name, String value) {
-        switch (type) {
-            case "integer":
-                return new Slot(name, Integer.parseInt(value));
-            case "entity":
-                return new Slot(name, value);
-            default:
-                throw new IllegalArgumentException(
-                      "Unknown slot type: " + type);
-        }
     }
 }
 

--- a/src/main/java/io/spokestack/spokestack/nlu/Slot.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/Slot.java
@@ -1,5 +1,7 @@
 package io.spokestack.spokestack.nlu;
 
+import java.util.Objects;
+
 /**
  * A slot extracted during intent classification.
  *
@@ -10,32 +12,79 @@ package io.spokestack.spokestack.nlu;
  * </p>
  */
 public final class Slot {
-    private final String slotName;
-    private final Object slotValue;
+    private final String name;
+    private final Object value;
 
     /**
      * Create a new slot.
      *
-     * @param name  The slot's name.
-     * @param value The slot's value.
+     * @param n   The slot's name.
+     * @param val The slot's value.
      */
-    public Slot(String name, Object value) {
-        this.slotName = name;
-        this.slotValue = value;
+    public Slot(String n, Object val) {
+        this.name = n;
+        this.value = val;
     }
 
     /**
      * @return The slot's name.
      */
     public String getName() {
-        return slotName;
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Slot slot = (Slot) o;
+        return getName().equals(slot.getName())
+              && getValue().equals(slot.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getName(), getValue());
+    }
+
+    @Override
+    public String toString() {
+        return "Slot{"
+              + "name='" + name + '\''
+              + ", value=" + value
+              + '}';
     }
 
     /**
      * @return The slot's value.
      */
     public Object getValue() {
-        return slotValue;
+        return value;
+    }
+
+    /**
+     * Create a typed slot by parsing its value using type information from the
+     * model's metadata.
+     *
+     * @param type  The type of slot to be parsed.
+     * @param name  The slot's name.
+     * @param value The string version of the slot's value to be parsed.
+     * @return A slot with a value parsed using the supplied type information.
+     */
+    public static Slot parse(String type, String name, String value) {
+        switch (type) {
+            case "integer":
+                return new Slot(name, Integer.parseInt(value));
+            case "entity":
+                return new Slot(name, value);
+            default:
+                throw new IllegalArgumentException(
+                      "Unknown slot type: " + type);
+        }
     }
 }
 

--- a/src/main/java/io/spokestack/spokestack/nlu/TraceListener.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/TraceListener.java
@@ -1,5 +1,7 @@
 package io.spokestack.spokestack.nlu;
 
+import io.spokestack.spokestack.util.EventTracer;
+
 /**
  * A simple interface implemented by classes interested in receiving trace
  * events.
@@ -8,7 +10,8 @@ public interface TraceListener {
 
     /**
      * A notification that a trace event has occurred.
+     * @param level The trace event's severity level.
      * @param message the trace event's message.
      */
-    void onTrace(String message);
+    void onTrace(EventTracer.Level level, String message);
 }

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/EncodedTokens.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/EncodedTokens.java
@@ -8,7 +8,7 @@ import java.util.List;
  * A simple data class that represents both the text of tokens produced from a
  * full string and identifiers associated with those tokens.
  */
-public class EncodedTokens {
+final class EncodedTokens {
 
     private final List<String> originalTokens;
     private final List<Integer> ids;
@@ -19,7 +19,7 @@ public class EncodedTokens {
      *
      * @param spaceSeparated The original string split on whitespace.
      */
-    public EncodedTokens(String[] spaceSeparated) {
+    EncodedTokens(String[] spaceSeparated) {
         this.ids = new ArrayList<>();
         this.originalTokens = Arrays.asList(spaceSeparated);
     }

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/EncodedTokens.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/EncodedTokens.java
@@ -1,0 +1,101 @@
+package io.spokestack.spokestack.nlu.tensorflow;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A simple data class that represents both the text of tokens produced from a
+ * full string and identifiers associated with those tokens.
+ */
+public class EncodedTokens {
+
+    private final List<String> originalTokens;
+    private final List<Integer> ids;
+    private List<Integer> originalIndices;
+
+    /**
+     * Create a new instance.
+     *
+     * @param spaceSeparated The original string split on whitespace.
+     */
+    public EncodedTokens(String[] spaceSeparated) {
+        this.ids = new ArrayList<>();
+        this.originalTokens = Arrays.asList(spaceSeparated);
+    }
+
+    /**
+     * @return The identifiers associated with the tokens.
+     */
+    public List<Integer> getIds() {
+        return ids;
+    }
+
+    /**
+     * Store the array mapping indices in the token ID list to those tokens'
+     * indices in the original token array.
+     *
+     * @param indices The mapping array.
+     * @throws IllegalStateException if the supplied array does not match the
+     *                               length of the token ID list.
+     */
+    public void setOriginalIndices(List<Integer> indices) {
+        if (indices.size() != ids.size()) {
+            throw new IllegalStateException(
+                  "original indices and the token ID list must be the "
+                        + "same length!");
+        }
+        this.originalIndices = indices;
+    }
+
+    /**
+     * Add a series of token ids.
+     *
+     * @param tokenIds The token identifiers.
+     */
+    public void addTokenIds(List<Integer> tokenIds) {
+        this.ids.addAll(tokenIds);
+    }
+
+    /**
+     * Use the index map created during encoding to recover a section of the
+     * original string. Like {@link List#subList(int, int)}, this method uses a
+     * half-open interval: the range returned includes the token referenced by
+     * {@code start} but excludes the one referenced by {@code stop} (unless a
+     * previous subtoken was also mapped to that token; see below).
+     *
+     * <p>
+     * For example, if the string {@code "The quick brown fox"} resulted in the
+     * token IDs {@code [1, 2, 3, 4]}, a call to {@code decodeRange(0, 2)} would
+     * return the text "The quick".
+     * </p>
+     *
+     * <p>
+     * If the end of the interval falls in the middle of a token that has been
+     * split into wordpieces, the interval will be implicitly expanded to the
+     * end of that original token.
+     * </p>
+     *
+     * @param start The position, inclusive, of the first token to recover.
+     * @param stop  The position, exclusive, of the last token to recover.
+     * @return The portion of the original string represented by the range of
+     * supplied token IDs.
+     * @throws IndexOutOfBoundsException if a requested index falls outside the
+     *                                   length of the token id array.
+     */
+    public String decodeRange(int start, int stop) {
+        if (stop < start || start < 0 || stop > this.ids.size()) {
+            String message = String.format(
+                  "Invalid token range: (%s, %s] for %s total tokens",
+                  start, stop, ids.size());
+            throw new IndexOutOfBoundsException(message);
+        }
+
+        int firstToken = this.originalIndices.get(start);
+        int lastToken = this.originalIndices.get(stop - 1);
+        // add one to compensate for the half-open interval of subList
+        int toIndex = Math.min(lastToken + 1, this.originalTokens.size());
+        return String.join(" ",
+              this.originalTokens.subList(firstToken, toIndex));
+    }
+}

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/Metadata.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/Metadata.java
@@ -1,0 +1,90 @@
+package io.spokestack.spokestack.nlu.tensorflow;
+
+/**
+ * A schema class used for metadata parsed from a JSON file that accompanies a
+ * TensorFlow Lite NLU model. The metadata contains the information necessary to
+ * translate the model's raw outputs into actionable intent and slot data.
+ */
+final class Metadata {
+
+    private Intent[] intents;
+    private String[] tags;
+
+    /**
+     * @return the metadata for all intents associated with this model.
+     */
+    public Intent[] getIntents() {
+        return intents;
+    }
+
+    /**
+     * @return all tags associated with this model.
+     */
+    public String[] getTags() {
+        return tags;
+    }
+
+    /**
+     * An intent definition. In model metadata, an intent consists of a name
+     * and a collection of slots recognized along with the intent.
+     */
+    static class Intent {
+        private String name;
+        private Slot[] slots;
+
+        Intent(String slotName, Slot[] slotMetas) {
+            this.name = slotName;
+            this.slots = slotMetas;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Slot[] getSlots() {
+            return slots;
+        }
+    }
+
+    /**
+     * A slot definition. In model metadata, a slot consists of a name, a type,
+     * and additional clarifying information that varies according to slot
+     * type.
+     *
+     * <p>
+     * For example, a slot with the "selset" type will list individual
+     * {@code selections} that contain aliases for each value. An "integer"
+     * slot may contain information about the range of values it should
+     * consider valid.
+     * </p>
+     */
+    static class Slot {
+        private String name;
+        private String type;
+
+        // optional slot contents for various slot types
+        private Selection[] selections;
+
+        Slot(String slotName, String slotType) {
+            this.name = slotName;
+            this.type = slotType;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getType() {
+            return type;
+        }
+    }
+
+    /**
+     * A single selection used by a selset to normalize concepts with varying
+     * surface forms into a single term.
+     */
+    static class Selection {
+        private String name;
+        private String[] aliases;
+    }
+}

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/SlotParser.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/SlotParser.java
@@ -1,0 +1,29 @@
+package io.spokestack.spokestack.nlu.tensorflow;
+
+import java.util.Map;
+
+/**
+ * An interface for components capable of parsing raw string slot values into
+ * concrete objects.
+ */
+public interface SlotParser {
+
+    /**
+     * Parse a raw string value from an utterance into a typed value for a
+     * concrete slot.
+     *
+     * <p>
+     * Implementers should throw an exception if the parsed value is invalid
+     * according to the supplied metadata.
+     * </p>
+     *
+     * @param metadata A map representing metadata for the particular slot being
+     *                 parsed.
+     * @param rawValue The string from a user utterance that represents a slot
+     *                 value.
+     * @return The slot represented by {@code value}.
+     * @throws Exception if there is an error during parsing.
+     */
+    Object parse(Map<String, Object> metadata, String rawValue)
+          throws Exception;
+}

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TFNLUOutput.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TFNLUOutput.java
@@ -1,0 +1,113 @@
+package io.spokestack.spokestack.nlu.tensorflow;
+
+import io.spokestack.spokestack.nlu.NLUContext;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An internal class to contain the business logic for turning raw model outputs
+ * into usable intents/slots.
+ */
+class TFNLUOutput {
+
+    TFNLUOutput() {
+    }
+
+    /**
+     * Extract the intent from the model's output tensor.
+     *
+     * @param metadata The metadata for the current NLU model.
+     * @param output   The output tensor containing the intent prediction.
+     * @return The intent from the model's output tensor.
+     */
+    public Metadata.Intent getIntent(Metadata metadata, ByteBuffer output) {
+        Metadata.Intent[] intents = metadata.getIntents();
+        int index = bufferArgMax(output, intents.length);
+        return intents[index];
+    }
+
+    /**
+     * Extract the slot values captured for a specific utterance from the
+     * model's slot tag output tensor.
+     *
+     * @param context  The context used to communicate trace events.
+     * @param metadata The metadata for the current NLU model.
+     * @param encoded  The original encoded input, used to determine string
+     *                 values for model output.
+     * @param output   The output tensor containing slot tag predictions.
+     * @return A map of slot name to raw string values.
+     */
+    public Map<String, String> getSlots(
+          NLUContext context,
+          Metadata metadata,
+          EncodedTokens encoded,
+          ByteBuffer output) {
+        int numTokens = encoded.getIds().size();
+        String[] tagLabels = getLabels(metadata, output, numTokens);
+        context.traceDebug("Tag labels: %s", Arrays.toString(tagLabels));
+        Map<Integer, Integer> slotLocations = new HashMap<>();
+        Integer curSlotStart = null;
+        for (int i = 0; i < tagLabels.length; i++) {
+            String label = tagLabels[i];
+            if (label.equals("o")) {
+                if (curSlotStart != null) {
+                    curSlotStart = null;
+                }
+            } else {
+                if (label.startsWith("b")) {
+                    curSlotStart = i;
+                }
+
+                // add both b_ and i_ tagged tokens to the current slot
+                if (curSlotStart != null) {
+                    slotLocations.put(curSlotStart, i + 1);
+                }
+            }
+        }
+
+        Map<String, String> slots = new HashMap<>();
+        for (Map.Entry<Integer, Integer> slotRange : slotLocations.entrySet()) {
+            String value = encoded.decodeRange(slotRange.getKey(),
+                  slotRange.getValue());
+            String slotName = tagLabels[slotRange.getKey()].substring(2);
+            slots.put(slotName, value);
+        }
+        return slots;
+    }
+
+    String[] getLabels(Metadata metadata, ByteBuffer output,
+                       int numTokens) {
+        int numTags = metadata.getTags().length;
+        String[] labels = new String[numTokens];
+        for (int i = 0; i < labels.length; i++) {
+            int index = bufferArgMax(output, numTags);
+            labels[i] = metadata.getTags()[index];
+        }
+        return labels;
+    }
+
+    private int bufferArgMax(ByteBuffer buffer, int n) {
+        float[] posteriors = new float[n];
+        for (int i = 0; i < n; i++) {
+            posteriors[i] = buffer.getFloat();
+        }
+        return argMax(posteriors);
+    }
+
+    private int argMax(float[] values) {
+        int maxIndex = 0;
+        float maxValue = values[0];
+
+        for (int i = 1; i < values.length; i++) {
+            float curVal = values[i];
+            if (curVal > maxValue) {
+                maxIndex = i;
+                maxValue = curVal;
+            }
+        }
+        return maxIndex;
+    }
+}

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TFNLUOutput.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TFNLUOutput.java
@@ -12,7 +12,7 @@ import java.util.Map;
  * An internal class to contain the business logic for turning raw model outputs
  * into usable intents/slots.
  */
-class TFNLUOutput {
+final class TFNLUOutput {
 
     TFNLUOutput() {
     }

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TensorflowNLU.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TensorflowNLU.java
@@ -1,0 +1,286 @@
+package io.spokestack.spokestack.nlu.tensorflow;
+
+import com.google.gson.Gson;
+import com.google.gson.stream.JsonReader;
+import io.spokestack.spokestack.SpeechConfig;
+import io.spokestack.spokestack.nlu.NLUResult;
+import io.spokestack.spokestack.nlu.NLUService;
+import io.spokestack.spokestack.nlu.Slot;
+import io.spokestack.spokestack.tensorflow.TensorflowModel;
+
+import java.io.FileReader;
+import java.io.Reader;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+/**
+ * On-device natural language understanding powered by DistilBERT and TensorFLow
+ * Lite.
+ *
+ * <p>
+ * This component uses a pre-trained TensorFlow Lite model to classify user
+ * utterances into intents and extract slot values. Metadata supplied alongside
+ * the model is used to determine the types of any slot values detected. Both
+ * model loading and classification are performed on a background thread.
+ * </p>
+ *
+ * <p>
+ * This component supports the following configuration properties:
+ * </p>
+ * <ul>
+ *   <li>
+ *      <b>nlu-model-path</b> (string, required): file system path to the NLU
+ *      TensorFlow Lite model.
+ *   </li>
+ *   <li>
+ *      <b>nlu-metadata-path</b> (string, required): file system path to the
+ *      model's metadata, used to decode intent and slot names and types.
+ *   </li>
+ *   <li>
+ *      <b>wordpiece-vocab-path</b> (string, required): file system path to the
+ *      wordpiece vocabulary file used by the wordpiece token encoder.
+ *   </li>
+ *   <li>
+ *      <b>nlu-input-length</b> (integer, optional): Padded length of the
+ *      model's input sequences. Defaults to 128 and should only be changed if
+ *      this parameter is explicitly set to a different value at training time.
+ *   </li>
+ * </ul>
+ */
+public class TensorflowNLU implements NLUService {
+
+    private static final int DEFAULT_TOKEN_LENGTH = 128;
+
+    private final ExecutorService executor =
+          Executors.newSingleThreadExecutor();
+    private final TextEncoder textEncoder;
+
+    private TensorflowModel nluModel = null;
+    private int tokenLength;
+    private int sepTokenId;
+    private int padTokenId;
+    private Metadata metadata;
+
+    /**
+     * Create a new NLU instance, automatically loading the TensorFlow model in
+     * the background.
+     *
+     * @param config Configuration for this component.
+     * @throws Exception If there is an error loading the model's metadata.
+     */
+    public TensorflowNLU(SpeechConfig config) throws Exception {
+        this(config, new TensorflowModel.Loader(),
+              new WordpieceTextEncoder(config));
+    }
+
+    /**
+     * Create a new NLU instance. Used for testing.
+     *
+     * @param config  Configuration for this component.
+     * @param loader  Tensorflow model loader.
+     * @param encoder Tokenizer used to create model inputs from raw text.
+     * @throws Exception If there is an error loading the model's metadata.
+     */
+    TensorflowNLU(SpeechConfig config, TensorflowModel.Loader loader,
+                  TextEncoder encoder)
+          throws Exception {
+        String modelPath = config.getString("nlu-model-path");
+        String metadataPath = config.getString("nlu-metadata-path");
+        this.tokenLength = config.getInteger("nlu-input-length",
+              DEFAULT_TOKEN_LENGTH);
+        this.textEncoder = encoder;
+        this.padTokenId = this.textEncoder.encodeSingle("[PAD]");
+        this.sepTokenId = this.textEncoder.encodeSingle("[SEP]");
+        FileReader reader = new FileReader(metadataPath);
+        this.executor.execute(() -> {
+            loadMetadata(reader);
+            loadModel(loader, modelPath);
+        });
+    }
+
+    private void loadMetadata(Reader fileReader) {
+        Gson gson = new Gson();
+        JsonReader reader = new JsonReader(fileReader);
+        this.metadata = gson.fromJson(reader, Metadata.class);
+    }
+
+    private void loadModel(TensorflowModel.Loader loader,
+                           String modelPath) {
+        this.nluModel = loader
+              .setPath(modelPath)
+              .load();
+        this.tokenLength = this.nluModel.inputs(0).capacity()
+              / this.metadata.getIntents().length
+              / this.nluModel.getInputSize();
+    }
+
+    @Override
+    public Future<NLUResult> classify(String utterance,
+                                      Map<String, Object> context) {
+        return this.executor.submit(() -> {
+            try {
+                return tfClassify(utterance);
+            } catch (Exception e) {
+                return new NLUResult.Builder(utterance)
+                      .withError(e)
+                      .build();
+            }
+        });
+    }
+
+    private NLUResult tfClassify(String utterance) {
+        EncodedTokens encoded = this.textEncoder.encode(utterance);
+        int[] tokenIds = pad(encoded.getIds());
+        this.nluModel.inputs(0).rewind();
+        for (int tokenId : tokenIds) {
+            this.nluModel.inputs(0).putInt(tokenId);
+        }
+
+        this.nluModel.run();
+
+        // interpret model outputs
+        Metadata.Intent intent = getIntent(this.nluModel.outputs(0));
+        Map<String, Slot> slots = getSlots(
+              this.nluModel.outputs(1),
+              intent,
+              encoded);
+
+        return new NLUResult.Builder(utterance)
+              .withIntent(intent.getName())
+              .withSlots(slots)
+              .build();
+    }
+
+    private int[] pad(List<Integer> ids) {
+        int[] padded = new int[this.tokenLength];
+        for (int i = 0; i < ids.size(); i++) {
+            padded[i] = ids.get(i);
+        }
+        if (ids.size() < this.tokenLength) {
+            padded[ids.size()] = sepTokenId;
+            // if padTokenId is 0, we can rely on the fact that that's the
+            // default value for primitive ints and not bother re-filling the
+            // array in a loop
+            if (padTokenId != 0) {
+                for (int i = ids.size() + 2; i < padded.length; i++) {
+                    padded[i] = padTokenId;
+                }
+            }
+        }
+        return padded;
+    }
+
+    private Metadata.Intent getIntent(ByteBuffer output) {
+        float[] posteriors = new float[this.metadata.getIntents().length];
+        for (int i = 0; i < posteriors.length; i++) {
+            posteriors[i] = output.getFloat();
+        }
+        int index = argMax(posteriors);
+        return this.metadata.getIntents()[index];
+    }
+
+    private Map<String, Slot> getSlots(ByteBuffer output,
+                                       Metadata.Intent intent,
+                                       EncodedTokens encoded) {
+        int numTokens = encoded.getIds().size();
+        String[] labels = getLabels(output, numTokens);
+        return parseSlots(intent, labels, encoded);
+    }
+
+    private String[] getLabels(ByteBuffer output, int numTokens) {
+        int numTags = this.metadata.getTags().length;
+        String[] labels = new String[numTokens];
+        for (int i = 0; i < labels.length; i++) {
+            float[] posteriors = new float[numTags];
+            for (int j = 0; j < numTags; j++) {
+                posteriors[j] = output.getFloat();
+            }
+            int index = argMax(posteriors);
+            labels[i] = this.metadata.getTags()[index];
+        }
+        return labels;
+    }
+
+    private int argMax(float[] values) {
+        int maxIndex = 0;
+        float maxValue = values[0];
+
+        for (int i = 1; i < values.length; i++) {
+            float curVal = values[i];
+            if (curVal > maxValue) {
+                maxIndex = i;
+                maxValue = curVal;
+            }
+        }
+        return maxIndex;
+    }
+
+    private Map<String, Slot> parseSlots(
+          Metadata.Intent intent,
+          String[] labels,
+          EncodedTokens encoded) {
+        Map<String, Slot> slots = new HashMap<>();
+        String curSlot = null;
+        int[] slotTokenRange = new int[2];
+        for (int i = 0; i < labels.length; i++) {
+            String label = labels[i];
+            if (label.equals("o")) {
+                if (curSlot != null) {
+                    String text = encoded.decodeRange(slotTokenRange[0],
+                          slotTokenRange[1] + 1);
+                    parseSlot(slots, curSlot, intent, text);
+                    curSlot = null;
+                }
+            } else {
+                if (label.startsWith("b")) {
+                    // two distinct slots, the first one word long, adjacent to
+                    // each other
+                    if (curSlot != null) {
+                        String text = encoded.decodeRange(slotTokenRange[0],
+                              i + 1);
+                        parseSlot(slots, curSlot, intent, text);
+                    }
+                    slotTokenRange[0] = i;
+                    curSlot = label.substring(2);
+                }
+
+                // add both b_ and i_ tagged tokens to the current slot
+                slotTokenRange[1] = i;
+            }
+
+        }
+        if (curSlot != null) {
+            String text = encoded.decodeRange(slotTokenRange[0],
+                  slotTokenRange[1] + 1);
+            parseSlot(slots, curSlot, intent, text);
+        }
+        return slots;
+    }
+
+    private void parseSlot(Map<String, Slot> slots,
+                           String slotName,
+                           Metadata.Intent intent,
+                           String slotValue) {
+        Metadata.Slot metaSlot = null;
+        for (Metadata.Slot slot : intent.getSlots()) {
+            if (slot.getName().equals(slotName)) {
+                metaSlot = slot;
+                break;
+            }
+        }
+        if (metaSlot == null) {
+            String message = String.format("no %s slot in %s intent", slotName,
+                  intent.getName());
+            throw new IllegalArgumentException(message);
+        }
+
+        slots.put(
+              slotName,
+              Slot.parse(metaSlot.getType(), slotName, slotValue));
+    }
+}

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TextEncoder.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TextEncoder.java
@@ -1,0 +1,40 @@
+package io.spokestack.spokestack.nlu.tensorflow;
+
+/**
+ * A simple interface for translating between raw text and neural model
+ * input. In addition to the duties of a typical tokenizer, this component
+ * also handles normalization and encoding the tokenized text into integers
+ * suitable for sending to a neural network.
+ */
+public interface TextEncoder {
+
+    /**
+     * Encode a raw string into identifiers for its constituent tokens. This
+     * represents the combination of typical normalization and tokenization
+     * string processing tasks and includes the identifier lookup as well for
+     * sake of efficiency. Implementors are free to subdivide this task however
+     * they see fit, but they should not expect pre-tokenized input.
+     *
+     * @param text The raw text to encode.
+     * @return The text and identifiers of the tokenized text enclosed in an
+     * {@link EncodedTokens} object.
+     */
+    EncodedTokens encode(String text);
+
+    /**
+     * Retrieves the identifier for the specified token without performing any
+     * tokenization. This method is designed to be used with special tokens
+     * like padding and input separators, so the provided token is expected to
+     * map directly to an ID.
+     *
+     * <p>
+     * If an unknown token is passed to this method, the implementation should
+     * map it to an identifier reserved for unknown tokens, and performance of
+     * the model will suffer accordingly.
+     * </p>
+     *
+     * @param token The token to encode.
+     * @return The token's identifier in the encoder's vocabulary.
+     */
+    int encodeSingle(String token);
+}

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/WordpieceTextEncoder.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/WordpieceTextEncoder.java
@@ -158,6 +158,8 @@ public class WordpieceTextEncoder implements TextEncoder {
     private boolean isInvalid(char ch) {
         int charType = Character.getType(ch);
         return (charType == Character.NON_SPACING_MARK
+              || charType == Character.DIRECTIONALITY_NONSPACING_MARK
+              || charType == Character.ENCLOSING_MARK
               || charType == Character.FORMAT
               || charType == Character.CONTROL);
     }

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/WordpieceTextEncoder.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/WordpieceTextEncoder.java
@@ -24,7 +24,7 @@ import java.util.concurrent.ThreadFactory;
  * produce the same results on CJK input as other Wordpiece tokenizers.
  * </p>
  */
-public class WordpieceTextEncoder implements TextEncoder {
+final class WordpieceTextEncoder implements TextEncoder {
     private static final String UNKNOWN = "[UNK]";
     private static final String SUFFIX_MARKER = "##";
 
@@ -41,7 +41,7 @@ public class WordpieceTextEncoder implements TextEncoder {
      *                   resource file.
      * @param nluContext Context used to surface loading errors.
      */
-    public WordpieceTextEncoder(SpeechConfig config, NLUContext nluContext) {
+    WordpieceTextEncoder(SpeechConfig config, NLUContext nluContext) {
         this(config, nluContext, Thread::new);
     }
 
@@ -55,7 +55,7 @@ public class WordpieceTextEncoder implements TextEncoder {
      * @param threadFactory Thread factory used for creating a resource loading
      *                      thread.
      */
-    public WordpieceTextEncoder(SpeechConfig config, NLUContext nluContext,
+    WordpieceTextEncoder(SpeechConfig config, NLUContext nluContext,
                                 ThreadFactory threadFactory) {
         String vocabFile = config.getString("wordpiece-vocab-path");
         this.context = nluContext;

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/WordpieceTextEncoder.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/WordpieceTextEncoder.java
@@ -1,0 +1,171 @@
+package io.spokestack.spokestack.nlu.tensorflow;
+
+import io.spokestack.spokestack.SpeechConfig;
+
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.text.Normalizer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Normalizes, tokenizes, and encodes text according to the
+ * <a href="https://arxiv.org/pdf/1609.08144.pdf">Wordpiece</a> method, using a
+ * pre-computed vocabulary for computing token IDs.
+ *
+ * <p>
+ * This version of the Wordpiece tokenizer does not currently have special
+ * handling for CJK (Chinese/Japanese/Korean) characters, so do not expect it to
+ * produce the same results on CJK input as other Wordpiece tokenizers.
+ * </p>
+ */
+public class WordpieceTextEncoder implements TextEncoder {
+    private static final String UNKNOWN = "[UNK]";
+    private static final String SUFFIX_MARKER = "##";
+
+    private HashMap<String, Integer> vocabulary;
+
+    /**
+     * Creates a new Wordpiece token encoder.
+     *
+     * @param config Configuration object containing the name of wordpiece
+     *               resource file.
+     * @throws Exception if there was an error loading the Wordpiece
+     *                   vocabulary.
+     */
+    public WordpieceTextEncoder(SpeechConfig config) throws Exception {
+        String vocabFile = config.getString("wordpiece-vocab-path");
+        this.vocabulary = loadVocab(vocabFile);
+    }
+
+    @Override
+    public int encodeSingle(String token) {
+        return this.vocabulary.getOrDefault(token,
+              this.vocabulary.get(UNKNOWN));
+    }
+
+    private HashMap<String, Integer> loadVocab(String fileName)
+          throws IOException {
+        FileInputStream inputStream = new FileInputStream(fileName);
+        BufferedReader reader = new BufferedReader(
+              new InputStreamReader(inputStream));
+        HashMap<String, Integer> words = new HashMap<>();
+        int index = 0;
+        String line = reader.readLine();
+        while (line != null) {
+            words.put(line, index);
+            line = reader.readLine();
+            index++;
+        }
+        inputStream.close();
+        reader.close();
+        return words;
+    }
+
+    @Override
+    public EncodedTokens encode(String text) {
+        String[] spaceSeparated = text.split("[\\s\\p{Space}]+");
+        EncodedTokens encoded = new EncodedTokens(spaceSeparated);
+
+        String token;
+        String[] punctSeparated;
+        List<Integer> pieceToOriginal = new ArrayList<>();
+        for (int i = 0; i < spaceSeparated.length; i++) {
+            token = spaceSeparated[i];
+            punctSeparated = normalizeAndStripPunct(token);
+            for (String subToken : punctSeparated) {
+                List<Integer> ids = encodeWordpieces(subToken);
+                encoded.addTokenIds(ids);
+                for (int j = 0; j < ids.size(); j++) {
+                    // add the same original token index once for each wordpiece
+                    // we've found
+                    pieceToOriginal.add(i);
+                }
+            }
+        }
+        encoded.setOriginalIndices(pieceToOriginal);
+        return encoded;
+    }
+
+    private String[] normalizeAndStripPunct(String word) {
+        // drop diacritics and split punctuation characters off the main word
+        // we do this via iteration in order to do both tasks in a single pass
+        // input to this method is expected to have been split on whitespace
+        List<String> subTokens = new ArrayList<>();
+        StringBuilder builder = new StringBuilder();
+        String decomposed = Normalizer.normalize(word, Normalizer.Form.NFD);
+        for (int i = 0; i < decomposed.length(); i++) {
+            char ch = decomposed.charAt(i);
+            if (isPunctuation(ch)) {
+                if (builder.length() > 0) {
+                    subTokens.add(builder.toString().toLowerCase());
+                    builder = new StringBuilder();
+                }
+                subTokens.add(String.valueOf(ch));
+            } else if (!isInvalid(ch)) {
+                builder.append(ch);
+            }
+        }
+        if (builder.length() > 0) {
+            subTokens.add(builder.toString().toLowerCase());
+        }
+
+        return subTokens.toArray(new String[0]);
+    }
+
+    private boolean isInvalid(char ch) {
+        int charType = Character.getType(ch);
+        return (charType == Character.NON_SPACING_MARK
+              || charType == Character.FORMAT
+              || charType == Character.CONTROL);
+    }
+
+    private boolean isPunctuation(char ch) {
+        int type = Character.getType(ch);
+        // all types between DASH and OTHER are also punctuation,
+        // but the quote groups are off by themselves
+        return (type >= Character.DASH_PUNCTUATION
+              && type <= Character.OTHER_PUNCTUATION)
+              || type == Character.INITIAL_QUOTE_PUNCTUATION
+              || type == Character.FINAL_QUOTE_PUNCTUATION;
+    }
+
+    private List<Integer> encodeWordpieces(String word) {
+        List<Integer> ids = new ArrayList<>();
+        String unencoded = encodeLongestWordpieces(word, "", ids);
+        if (unencoded != null) {
+            // if we can't encode part of the word, we can't encode any of it;
+            // there is no ##[UNK], for good reason
+            ids.clear();
+            ids.add(this.vocabulary.get(UNKNOWN));
+        }
+        return ids;
+    }
+
+    private String encodeLongestWordpieces(String text,
+                                           String prefix,
+                                           List<Integer> soFar) {
+        String combined = prefix + text;
+        if (this.vocabulary.containsKey(combined)) {
+            soFar.add(this.vocabulary.get(combined));
+            return null;
+        }
+
+        String unencoded = combined;
+        int minIndex = prefix.isEmpty() ? 0 : prefix.length();
+        for (int i = combined.length() - 1; i > minIndex; i--) {
+            String subToken = combined.substring(0, i);
+            Integer id = this.vocabulary.get(subToken);
+            if (id != null) {
+                soFar.add(id);
+                unencoded = encodeLongestWordpieces(
+                      combined.substring(i), SUFFIX_MARKER, soFar);
+                break;
+            }
+        }
+        return unencoded;
+    }
+}

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/package-info.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * This package contains components used to perform NLU with an on-device
+ * TensorFlow Lite model.
+ */
+package io.spokestack.spokestack.nlu.tensorflow;

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/parsers/DigitsParser.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/parsers/DigitsParser.java
@@ -1,0 +1,139 @@
+package io.spokestack.spokestack.nlu.tensorflow.parsers;
+
+import io.spokestack.spokestack.nlu.tensorflow.SlotParser;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * This parser converts a string representation of a sequence of digits into the
+ * corresponding sequence of digits. Strings may include english cardinal
+ * representations of numbers, as well as some simple homophones.
+ *
+ * <p>
+ * Only positive values are recognized.
+ * </p>
+ *
+ * <p>
+ * These may include hyphenated or unhyphenated numbers from twenty through
+ * ninety-nine. Unhyphenated numbers are automatically joined.
+ * </p>
+ *
+ * <p>
+ * Allowing unhyphenated double-digit numbers creates an ambiguity that limits
+ * some representations, for example "sixty five thousand" could be parsed as
+ * either 65000 or 605000. For this reason, 2- and 3-digit numbers are
+ * restricted to even hundreds/thousands. In this model, the above number would
+ * always be parsed as "65000" -- in other words, "sixty five thousand one"
+ * would be parsed as "650001". This limitation should be acceptable for most
+ * multi-digit requirements (telephone numbers, social security numbers, etc.)
+ * </p>
+ */
+public class DigitsParser implements SlotParser {
+    private static final Map<String, Integer> ENG_ZERO = new HashMap<>();
+    private static final Map<String, Integer> ENG_MOD10 = new HashMap<>();
+    private static final Map<String, Integer> ENG_MOD20 = new HashMap<>();
+    private static final Map<String, Integer> ENG_DIV10 = new HashMap<>();
+    private static final Map<String, Integer> ENG_EXP10 = new HashMap<>();
+    private static final Pattern DIGIT_SPLIT_RE = Pattern.compile("[-,()\\s]+");
+
+    /**
+     * Create a new digit parser.
+     */
+    public DigitsParser() {
+        initMaps();
+    }
+
+    private void initMaps() {
+        ENG_ZERO.put("zero", 0);
+        ENG_ZERO.put("oh", 0);
+        ENG_ZERO.put("owe", 0);
+
+        ENG_MOD10.put("one", 1);
+        ENG_MOD10.put("won", 1);
+        ENG_MOD10.put("two", 2);
+        ENG_MOD10.put("to", 2);
+        ENG_MOD10.put("too", 2);
+        ENG_MOD10.put("three", 3);
+        ENG_MOD10.put("four", 4);
+        ENG_MOD10.put("for", 4);
+        ENG_MOD10.put("fore", 4);
+        ENG_MOD10.put("five", 5);
+        ENG_MOD10.put("six", 6);
+        ENG_MOD10.put("sicks", 6);
+        ENG_MOD10.put("sics", 6);
+        ENG_MOD10.put("seven", 7);
+        ENG_MOD10.put("eight", 8);
+        ENG_MOD10.put("ate", 8);
+        ENG_MOD10.put("nine", 9);
+
+        ENG_MOD20.put("ten", 10);
+        ENG_MOD20.put("tin", 10);
+        ENG_MOD20.put("eleven", 11);
+        ENG_MOD20.put("twelve", 12);
+        ENG_MOD20.put("thirteen", 13);
+        ENG_MOD20.put("fourteen", 14);
+        ENG_MOD20.put("fifteen", 15);
+        ENG_MOD20.put("sixteen", 16);
+        ENG_MOD20.put("seventeen", 17);
+        ENG_MOD20.put("eighteen", 18);
+        ENG_MOD20.put("nineteen", 19);
+
+        ENG_DIV10.put("twenty", 2);
+        ENG_DIV10.put("thirty", 3);
+        ENG_DIV10.put("forty", 4);
+        ENG_DIV10.put("fifty", 5);
+        ENG_DIV10.put("sixty", 6);
+        ENG_DIV10.put("seventy", 7);
+        ENG_DIV10.put("eighty", 8);
+        ENG_DIV10.put("ninety", 9);
+
+        ENG_EXP10.put("hundred", 2);
+        ENG_EXP10.put("thousand", 3);
+    }
+
+    @Override
+    public Object parse(Map<String, Object> metadata,
+                        String rawValue) {
+        Object count = metadata.get("count");
+        Double numDigits = (count == null) ? null : (double) count;
+        String normalized = rawValue.toLowerCase();
+        StringBuilder resultBuilder = new StringBuilder();
+        String[] tokens = DIGIT_SPLIT_RE.split(normalized);
+        for (int i = 0; i < tokens.length; i++) {
+            String next = (i < tokens.length - 1) ? tokens[i + 1] : null;
+            resultBuilder.append(parseSingle(tokens[i], next));
+        }
+        if ((numDigits == null && resultBuilder.length() > 0)
+            || (numDigits != null && resultBuilder.length() == numDigits)) {
+            return resultBuilder.toString();
+        }
+        throw new IllegalArgumentException(
+              "invalid digit string: " + resultBuilder.toString());
+    }
+
+    private String parseSingle(String numStr, String next) {
+        if (ENG_ZERO.containsKey(numStr)) {
+            return String.valueOf(ENG_ZERO.get(numStr));
+        } else if (ENG_MOD10.containsKey(numStr)) {
+            return String.valueOf(ENG_MOD10.get(numStr));
+        } else if (ENG_MOD20.containsKey(numStr)) {
+            return String.valueOf(ENG_MOD20.get(numStr));
+        } else if (ENG_DIV10.containsKey(numStr)
+              && ENG_MOD10.containsKey(next)) {
+            return String.valueOf(ENG_DIV10.get(numStr));
+        } else if (ENG_DIV10.containsKey(numStr)) {
+            return String.valueOf(ENG_DIV10.get(numStr) * 10);
+        } else if (ENG_EXP10.containsKey(numStr)) {
+            int exp = ENG_EXP10.get(numStr);
+            return String.format("%0" + exp + "d", 0);
+        } else {
+            try {
+                return String.valueOf(Long.parseLong(numStr));
+            } catch (NumberFormatException nfe) {
+                return "";
+            }
+        }
+    }
+}

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/parsers/DigitsParser.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/parsers/DigitsParser.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
  * multi-digit requirements (telephone numbers, social security numbers, etc.)
  * </p>
  */
-public class DigitsParser implements SlotParser {
+public final class DigitsParser implements SlotParser {
     private static final Map<String, Integer> ENG_ZERO = new HashMap<>();
     private static final Map<String, Integer> ENG_MOD10 = new HashMap<>();
     private static final Map<String, Integer> ENG_MOD20 = new HashMap<>();

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/parsers/IdentityParser.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/parsers/IdentityParser.java
@@ -1,0 +1,23 @@
+package io.spokestack.spokestack.nlu.tensorflow.parsers;
+
+import io.spokestack.spokestack.nlu.tensorflow.SlotParser;
+
+import java.util.Map;
+
+/**
+ * A parser that does not alter string slot values recognized by the model.
+ */
+public class IdentityParser implements SlotParser {
+
+    /**
+     * Create a new identity parser.
+     */
+    public IdentityParser() {
+    }
+
+    @Override
+    public Object parse(Map<String, Object> metadata,
+                        String rawValue) {
+        return rawValue;
+    }
+}

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/parsers/IdentityParser.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/parsers/IdentityParser.java
@@ -7,7 +7,7 @@ import java.util.Map;
 /**
  * A parser that does not alter string slot values recognized by the model.
  */
-public class IdentityParser implements SlotParser {
+public final class IdentityParser implements SlotParser {
 
     /**
      * Create a new identity parser.

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/parsers/IntegerParser.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/parsers/IntegerParser.java
@@ -1,0 +1,178 @@
+package io.spokestack.spokestack.nlu.tensorflow.parsers;
+
+import io.spokestack.spokestack.nlu.tensorflow.SlotParser;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * This parser converts string representations of integers into integers. These
+ * strings may be digits or cardinal or ordinal number names. Strict hyphenation
+ * of two-digit numbers is optional.
+ *
+ * <p>
+ * Only positive values are recognized.
+ * </p>
+ *
+ * <p>
+ * A "range" property is expected in the slot's metadata; this property
+ * represents a half-open interval of (start, end] for the range of values the
+ * parser should accept. Regardless of the end of the interval, the maximum
+ * value that will be parsed is Java's {@link Integer#MAX_VALUE}; values greater
+ * than this will result in an exception.
+ * </p>
+ */
+public class IntegerParser implements SlotParser {
+    private static final Map<String, Integer> WORD_TO_NUM = new HashMap<>();
+    private static final Map<String, Integer> MULTIPLIERS = new HashMap<>();
+    private static final Pattern DIGIT_SPLIT_RE = Pattern.compile("[-,()\\s]");
+
+    /**
+     * Create a new integer parser.
+     */
+    public IntegerParser() {
+        initMaps();
+    }
+
+    private void initMaps() {
+        WORD_TO_NUM.put("oh", 0);
+        WORD_TO_NUM.put("owe", 0);
+        WORD_TO_NUM.put("zero", 0);
+        WORD_TO_NUM.put("won", 1);
+        WORD_TO_NUM.put("one", 1);
+        WORD_TO_NUM.put("first", 1);
+        WORD_TO_NUM.put("to", 2);
+        WORD_TO_NUM.put("too", 2);
+        WORD_TO_NUM.put("two", 2);
+        WORD_TO_NUM.put("second", 2);
+        WORD_TO_NUM.put("three", 3);
+        WORD_TO_NUM.put("third", 3);
+        WORD_TO_NUM.put("for", 4);
+        WORD_TO_NUM.put("fore", 4);
+        WORD_TO_NUM.put("four", 4);
+        WORD_TO_NUM.put("five", 5);
+        WORD_TO_NUM.put("fif", 5);
+        WORD_TO_NUM.put("sicks", 6);
+        WORD_TO_NUM.put("sics", 6);
+        WORD_TO_NUM.put("six", 6);
+        WORD_TO_NUM.put("seven", 7);
+        WORD_TO_NUM.put("ate", 8);
+        WORD_TO_NUM.put("eight", 8);
+        WORD_TO_NUM.put("eighth", 8);
+        WORD_TO_NUM.put("nine", 9);
+        WORD_TO_NUM.put("ninth", 9);
+        WORD_TO_NUM.put("tin", 10);
+        WORD_TO_NUM.put("ten", 10);
+        WORD_TO_NUM.put("eleven", 11);
+        WORD_TO_NUM.put("twelve", 12);
+        WORD_TO_NUM.put("twelf", 12);
+        WORD_TO_NUM.put("thirteen", 13);
+        WORD_TO_NUM.put("fourteen", 14);
+        WORD_TO_NUM.put("fifteen", 15);
+        WORD_TO_NUM.put("sixteen", 16);
+        WORD_TO_NUM.put("seventeen", 17);
+        WORD_TO_NUM.put("eighteen", 18);
+        WORD_TO_NUM.put("nineteen", 19);
+        WORD_TO_NUM.put("twenty", 20);
+        WORD_TO_NUM.put("twentie", 20);
+        WORD_TO_NUM.put("thirty", 30);
+        WORD_TO_NUM.put("thirtie", 30);
+        WORD_TO_NUM.put("forty", 40);
+        WORD_TO_NUM.put("fortie", 40);
+        WORD_TO_NUM.put("fifty", 50);
+        WORD_TO_NUM.put("fiftie", 50);
+        WORD_TO_NUM.put("sixty", 60);
+        WORD_TO_NUM.put("sixtie", 60);
+        WORD_TO_NUM.put("seventy", 70);
+        WORD_TO_NUM.put("seventie", 70);
+        WORD_TO_NUM.put("eighty", 80);
+        WORD_TO_NUM.put("eightie", 80);
+        WORD_TO_NUM.put("ninety", 90);
+        WORD_TO_NUM.put("ninetie", 90);
+
+        MULTIPLIERS.put("hundred", 100);
+        MULTIPLIERS.put("thousand", 1000);
+        MULTIPLIERS.put("million", 1000000);
+        MULTIPLIERS.put("billion", 1000000000);
+        WORD_TO_NUM.putAll(MULTIPLIERS);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Object parse(Map<String, Object> metadata,
+                        String rawValue) {
+        List<Double> range = null;
+        Object rawRange = metadata.get("range");
+        if (rawRange != null) {
+            range = (List<Double>) rawRange;
+        }
+        String normalized = rawValue.toLowerCase().trim();
+        List<Integer> parsedInts = new ArrayList<>();
+        String[] tokens = DIGIT_SPLIT_RE.split(normalized);
+        for (String token : tokens) {
+            try {
+                int parsed = Integer.parseInt(token);
+                parsedInts.add(parsed);
+            } catch (NumberFormatException nfe) {
+                parseReduce(token, parsedInts);
+            }
+        }
+        int result = sum(parsedInts);
+        if (isInRange(result, range)) {
+            return result;
+        }
+        throw new IllegalArgumentException("number out of range: " + result);
+    }
+
+    private void parseReduce(String numStr, List<Integer> soFar) {
+        String toParse = numStr;
+        if (toParse.endsWith("th")) {
+            toParse = toParse.substring(0, toParse.length() - 2);
+        }
+        if (!WORD_TO_NUM.containsKey(toParse)) {
+            throw new IllegalArgumentException("Invalid integer: " + toParse);
+        }
+
+        if (MULTIPLIERS.containsKey(toParse)) {
+            List<Integer> sum = collapse(MULTIPLIERS.get(toParse), soFar);
+            soFar.clear();
+            soFar.addAll(sum);
+        } else {
+            soFar.add(WORD_TO_NUM.get(toParse));
+        }
+    }
+
+    private List<Integer> collapse(int multiplier, List<Integer> soFar) {
+        List<Integer> collapsed = new ArrayList<>();
+        int sum = 0;
+        for (Integer num : soFar) {
+            if (num > multiplier) {
+                collapsed.add(num);
+            } else {
+                sum += num;
+            }
+        }
+        sum = (sum > 0) ? sum : 1;
+        collapsed.add(sum * multiplier);
+        return collapsed;
+    }
+
+    private int sum(List<Integer> parsed) {
+        int sum = 0;
+        for (Integer num : parsed) {
+            sum += num;
+        }
+        return sum;
+    }
+
+    private boolean isInRange(int val, List<Double> range) {
+        return range == null
+              || (val > 0
+              && range.get(0) < range.get(1)
+              && val >= range.get(0)
+              && val < range.get(1));
+    }
+}

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/parsers/IntegerParser.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/parsers/IntegerParser.java
@@ -25,7 +25,7 @@ import java.util.regex.Pattern;
  * than this will result in an exception.
  * </p>
  */
-public class IntegerParser implements SlotParser {
+public final class IntegerParser implements SlotParser {
     private static final Map<String, Integer> WORD_TO_NUM = new HashMap<>();
     private static final Map<String, Integer> MULTIPLIERS = new HashMap<>();
     private static final Pattern DIGIT_SPLIT_RE = Pattern.compile("[-,()\\s]");

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/parsers/SelsetParser.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/parsers/SelsetParser.java
@@ -8,7 +8,7 @@ import java.util.Map;
 /**
  * A parser that resolves selset values to their canonical names.
  */
-public class SelsetParser implements SlotParser {
+public final class SelsetParser implements SlotParser {
 
     /**
      * Create a new selset parser.

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/parsers/SelsetParser.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/parsers/SelsetParser.java
@@ -1,0 +1,50 @@
+package io.spokestack.spokestack.nlu.tensorflow.parsers;
+
+import io.spokestack.spokestack.nlu.tensorflow.SlotParser;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A parser that resolves selset values to their canonical names.
+ */
+public class SelsetParser implements SlotParser {
+
+    /**
+     * Create a new selset parser.
+     */
+    public SelsetParser() {
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Object parse(Map<String, Object> metadata,
+                        String rawValue) {
+        List<Object> selections = null;
+        try {
+            selections = (List<Object>) metadata.get("selections");
+        } catch (ClassCastException e) {
+            // do nothing; catch with the null check below
+        }
+
+        if (selections == null) {
+            throw new IllegalArgumentException("invalid selset facets");
+        }
+
+        String normalized = rawValue.toLowerCase();
+        for (Object selection : selections) {
+            Map<String, Object> selMap = (Map<String, Object>) selection;
+            String name = String.valueOf(selMap.get("name"));
+            if (name.toLowerCase().equals(normalized)) {
+                return name;
+            }
+            List<String> aliases = (List<String>) selMap.get("aliases");
+            for (String alias : aliases) {
+                if (alias.toLowerCase().equals(normalized)) {
+                    return name;
+                }
+            }
+        }
+        throw new IllegalArgumentException("invalid alias: " + rawValue);
+    }
+}

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/parsers/package-info.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/parsers/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * This package contains slot parsers provided by default with Spokestack and
+ * utility code used across different slot types.
+ */
+package io.spokestack.spokestack.nlu.tensorflow.parsers;

--- a/src/main/java/io/spokestack/spokestack/util/EventTracer.java
+++ b/src/main/java/io/spokestack/spokestack/util/EventTracer.java
@@ -1,7 +1,7 @@
 package io.spokestack.spokestack.util;
 
 /**
- * A utility class for components capable of dispatching trace events,
+ * A utility class for components capable of dispatching trace/logging events,
  * encapsulating the logic of checking an event's specified level against a
  * preconfigured threshold to determine whether the event message should be
  * formatted and dispatched, similar to the Java logger.
@@ -16,6 +16,10 @@ public final class EventTracer {
         PERF(20),
         /** informational traces. */
         INFO(30),
+        /** warning traces. */
+        WARN(50),
+        /** error traces. */
+        ERROR(80),
         /** no traces. */
         NONE(100);
 

--- a/src/main/java/io/spokestack/spokestack/util/Tuple.java
+++ b/src/main/java/io/spokestack/spokestack/util/Tuple.java
@@ -1,0 +1,36 @@
+package io.spokestack.spokestack.util;
+
+/**
+ * A simple wrapper for an immutable tuple of objects.
+ * @param <T> The type of the tuple's first member.
+ * @param <U> The type of the tuple's second member.
+ */
+public final class Tuple<T, U> {
+
+    private final T first;
+    private final U second;
+
+    /**
+     * Create a new tuple.
+     * @param val1 The first value.
+     * @param val2 The second value.
+     */
+    public Tuple(T val1, U val2) {
+        this.first = val1;
+        this.second = val2;
+    }
+
+    /**
+     * @return The tuple's first object.
+     */
+    public T first() {
+        return first;
+    }
+
+    /**
+     * @return The tuple's second object.
+     */
+    public U second() {
+        return second;
+    }
+}

--- a/src/test/java/io/spokestack/spokestack/nlu/NLUContextTest.java
+++ b/src/test/java/io/spokestack/spokestack/nlu/NLUContextTest.java
@@ -51,7 +51,7 @@ public class NLUContextTest implements TraceListener {
     }
 
     @Override
-    public void onTrace(String message) {
+    public void onTrace(EventTracer.Level level, String message) {
         this.message = message;
     }
 }

--- a/src/test/java/io/spokestack/spokestack/nlu/SlotTest.java
+++ b/src/test/java/io/spokestack/spokestack/nlu/SlotTest.java
@@ -1,0 +1,46 @@
+package io.spokestack.spokestack.nlu;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SlotTest {
+
+    @Test
+    public void equals() {
+        Slot one = new Slot("test", "1", 1);
+        assertNotEquals(one, new Object());
+        assertEquals(one, one);
+
+        Slot alsoOne = new Slot("test", "1", 1);
+        assertEquals(one, alsoOne);
+
+        Slot two = new Slot("test", "1", 2);
+        assertNotEquals(one, two);
+        two = new Slot("test", "2", 1);
+        assertNotEquals(one, two);
+        two = new Slot("two", "1", 1);
+        assertNotEquals(one, two);
+    }
+
+    @Test
+    public void testHashCode() {
+        Slot one = new Slot("test", "1", 1);
+        Slot alsoOne = new Slot("test", "1", 1);
+        assertEquals(one.hashCode(), alsoOne.hashCode());
+
+        // original value does not matter for hashcode
+        alsoOne = new Slot("test", "2", 1);
+        assertEquals(one.hashCode(), alsoOne.hashCode());
+
+        Slot two = new Slot("test", "2", 2);
+        assertNotEquals(one.hashCode(), two.hashCode());
+    }
+
+    @Test
+    void testToString() {
+        Slot one = new Slot("test", "1", 1);
+        String expected = "Slot{name=\"test\", rawValue=1, value=1}";
+        assertEquals(expected, one.toString());
+    }
+}

--- a/src/test/java/io/spokestack/spokestack/nlu/tensorflow/EncodedTokensTest.java
+++ b/src/test/java/io/spokestack/spokestack/nlu/tensorflow/EncodedTokensTest.java
@@ -1,0 +1,65 @@
+package io.spokestack.spokestack.nlu.tensorflow;
+
+import org.junit.Test;
+
+import java.text.Normalizer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class EncodedTokensTest {
+
+    private static final String INITIAL_SPLIT_RE = "\\s+";
+
+    @Test
+    public void testDecode() {
+        String[] spacedTokens = new String[]{"test", "text"};
+        final EncodedTokens invalid = new EncodedTokens(spacedTokens);
+        invalid.addTokenIds(Arrays.asList(0, 0, 0, 0, 0, 0, 0));
+        assertThrows(IllegalStateException.class,
+              () -> invalid.setOriginalIndices(new ArrayList<>()));
+
+        String text = "I made the WORST decision.";
+        spacedTokens = text.split(INITIAL_SPLIT_RE);
+        EncodedTokens encoded = new EncodedTokens(spacedTokens);
+        encoded.addTokenIds(Arrays.asList(0, 0, 0, 0, 0, 0, 0));
+        List<Integer> originalIndices = Arrays.asList(0, 1, 2, 3, 4, 5, 5);
+        encoded.setOriginalIndices(originalIndices);
+        // valid range
+        assertEquals(text, encoded.decodeRange(0, 7));
+
+        // invalid ranges
+        final EncodedTokens finalEncoded = encoded;
+        assertThrows(IndexOutOfBoundsException.class,
+              () -> finalEncoded.decodeRange(-1, 3));
+        assertThrows(IndexOutOfBoundsException.class,
+              () -> finalEncoded.decodeRange(0, 8));
+        assertThrows(IndexOutOfBoundsException.class,
+              () -> finalEncoded.decodeRange(3, 2));
+
+        text = "I";
+        assertEquals(text, encoded.decodeRange(0, 1));
+
+        text = Normalizer.normalize("thé\t\tearl grey", Normalizer.Form.NFD);
+        spacedTokens = text.split(INITIAL_SPLIT_RE);
+        encoded = new EncodedTokens(spacedTokens);
+        encoded.addTokenIds(Arrays.asList(0, 0, 0));
+        originalIndices = Arrays.asList(0, 1, 2);
+        encoded.setOriginalIndices(originalIndices);
+        String expected = text.replaceAll(INITIAL_SPLIT_RE, " ");
+        assertEquals(expected, encoded.decodeRange(0, 3));
+        assertEquals("earl", encoded.decodeRange(1, 2));
+
+        text = "\"(the)\" weird-est punctuation";
+        spacedTokens = text.split(INITIAL_SPLIT_RE);
+        encoded = new EncodedTokens(spacedTokens);
+        encoded.addTokenIds(Arrays.asList(0, 0, 0, 0, 0, 0, 0));
+        originalIndices = Arrays.asList(0, 0, 0, 0, 0, 1, 2);
+        encoded.setOriginalIndices(originalIndices);
+        assertEquals("\"(the)\"", encoded.decodeRange(0, 5));
+    }
+}

--- a/src/test/java/io/spokestack/spokestack/nlu/tensorflow/TensorflowNLUTest.java
+++ b/src/test/java/io/spokestack/spokestack/nlu/tensorflow/TensorflowNLUTest.java
@@ -1,0 +1,172 @@
+package io.spokestack.spokestack.nlu.tensorflow;
+
+import com.google.gson.Gson;
+import com.google.gson.stream.JsonReader;
+import io.spokestack.spokestack.SpeechConfig;
+import io.spokestack.spokestack.nlu.NLUResult;
+import io.spokestack.spokestack.nlu.Slot;
+import io.spokestack.spokestack.tensorflow.TensorflowModel;
+import org.junit.Test;
+
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class TensorflowNLUTest {
+
+    @Test
+    public void classify() throws Exception {
+        TestEnv env = new TestEnv(testConfig());
+
+        String utterance = "error";
+        NLUResult result = env.classify(utterance).get();
+        assertEquals(IllegalStateException.class, result.getError().getClass());
+        assertEquals(utterance, result.getUtterance());
+        assertNull(result.getIntent());
+        assertNull(result.getSlots());
+        assertNull(result.getContext());
+
+        utterance = "this code is for test 1";
+        float[] intentResult =
+              buildIntentResult(2, env.metadata.getIntents().length);
+        float[] tagResult =
+              new float[utterance.split(" ").length * env.metadata.getTags().length];
+        setTag(tagResult, env.metadata.getTags().length, 0, 1);
+        setTag(tagResult, env.metadata.getTags().length, 1, 2);
+        setTag(tagResult, env.metadata.getTags().length, 5, 3);
+        env.testModel.setOutputs(intentResult, tagResult);
+        result = env.classify(utterance).get();
+
+        Map<String, Slot> slots = new HashMap<>();
+        slots.put("noun_phrase", new Slot("noun_phrase", "this code"));
+        slots.put("test_num", new Slot("test_num", 1));
+
+        assertNull(result.getError());
+        assertEquals("describe_test", result.getIntent());
+        assertEquals(slots, result.getSlots());
+        assertEquals(utterance, result.getUtterance());
+        assertTrue(result.getContext().isEmpty());
+    }
+
+    private float[] buildIntentResult(int index, int numIntents) {
+        float[] result = new float[numIntents];
+        result[index] = 10;
+        return result;
+    }
+
+    private void setTag(float[] tagResult, int numTags,
+                        int tokenIndex, int tagIndex) {
+        tagResult[tokenIndex * numTags + tagIndex] = 10;
+    }
+
+    public SpeechConfig testConfig() {
+        return new SpeechConfig()
+              .put("nlu-model-path", "model-path")
+              .put("nlu-metadata-path", "src/test/resources/nlu.json")
+              .put("nlu-input-length", 6);
+    }
+
+    public static class TestModel extends TensorflowModel {
+        public TestModel(TensorflowModel.Loader loader) {
+            super(loader);
+        }
+
+        public void run() {
+            this.inputs(0).rewind();
+            this.outputs(0).rewind();
+            this.outputs(1).rewind();
+        }
+
+        public final void setOutputs(float[] intentsOut, float[] tagsOut) {
+            this.outputs(0).rewind();
+            for (float f : intentsOut) {
+                this.outputs(0).putFloat(f);
+            }
+            this.outputs(1).rewind();
+            for (float o : tagsOut) {
+                this.outputs(1).putFloat(o);
+            }
+        }
+    }
+
+    public static class TestEnv implements TextEncoder {
+        public final TensorflowModel.Loader loader;
+        public final TensorflowNLUTest.TestModel testModel;
+        public final TensorflowNLU nlu;
+        public final Metadata metadata;
+
+        public TestEnv(SpeechConfig config) throws Exception {
+            // fetch configuration parameters
+            int inputLength = config.getInteger("nlu-input-length");
+            String metadataPath = config.getString("nlu-metadata-path");
+            this.metadata = loadMetadata(metadataPath);
+
+            // create/mock tensorflow-lite models
+            this.loader = spy(TensorflowModel.Loader.class);
+            this.testModel = mock(TensorflowNLUTest.TestModel.class);
+
+            doReturn(ByteBuffer
+                  .allocateDirect(inputLength * metadata.getIntents().length * 4)
+                  .order(ByteOrder.nativeOrder()))
+                  .when(this.testModel).inputs(0);
+            doReturn(ByteBuffer
+                  .allocateDirect(metadata.getIntents().length * 4)
+                  .order(ByteOrder.nativeOrder()))
+                  .when(this.testModel).outputs(0);
+            doReturn(ByteBuffer
+                  .allocateDirect(inputLength * metadata.getTags().length * 4)
+                  .order(ByteOrder.nativeOrder()))
+                  .when(this.testModel).outputs(1);
+            doReturn(4).when(this.testModel).getInputSize();
+            doCallRealMethod().when(this.testModel).run();
+            doReturn(this.testModel)
+                  .when(this.loader).load();
+
+            this.nlu = new TensorflowNLU(config, this.loader, this);
+        }
+
+        private Metadata loadMetadata(String metadataPath)
+              throws FileNotFoundException {
+            FileReader fileReader = new FileReader(metadataPath);
+            Gson gson = new Gson();
+            JsonReader reader = new JsonReader(fileReader);
+            return gson.fromJson(reader, Metadata.class);
+        }
+
+        public Future<NLUResult> classify(String utterance) {
+            return nlu.classify(utterance, new HashMap<>());
+        }
+
+        @Override
+        public int encodeSingle(String token) {
+            return 0;
+        }
+
+        @Override
+        public EncodedTokens encode(String text) {
+            if (text.equals("error")) {
+                throw new IllegalStateException("forced test error");
+            }
+            String[] split = text.split(" ");
+            EncodedTokens encoded = new EncodedTokens(split);
+            List<Integer> ids = new ArrayList<>();
+            List<Integer> originalIndices = new ArrayList<>();
+            for (int i = 0; i < split.length; i++) {
+                ids.add(0);
+                originalIndices.add(i);
+            }
+            encoded.addTokenIds(ids);
+            encoded.setOriginalIndices(originalIndices);
+            return encoded;
+        }
+    }
+}

--- a/src/test/java/io/spokestack/spokestack/nlu/tensorflow/TensorflowNLUTest.java
+++ b/src/test/java/io/spokestack/spokestack/nlu/tensorflow/TensorflowNLUTest.java
@@ -62,9 +62,24 @@ public class TensorflowNLUTest {
         NLUResult result = env.classify(utterance).get();
         assertEquals(IllegalStateException.class, result.getError().getClass());
         assertEquals(utterance, result.getUtterance());
+        assertEquals(0, result.getConfidence());
         assertNull(result.getIntent());
-        assertNull(result.getSlots());
-        assertNull(result.getContext());
+        assertTrue(result.getContext().isEmpty());
+        assertTrue(result.getSlots().isEmpty());
+
+        StringBuilder tooManyTokens = new StringBuilder();
+        for (int i = 0; i <= env.nlu.getMaxTokens(); i++) {
+           tooManyTokens.append("a ");
+        }
+        utterance = tooManyTokens.toString();
+        result = env.classify(utterance).get();
+        assertEquals(IllegalArgumentException.class,
+              result.getError().getClass());
+        assertEquals(utterance, result.getUtterance());
+        assertEquals(0, result.getConfidence());
+        assertNull(result.getIntent());
+        assertTrue(result.getContext().isEmpty());
+        assertTrue(result.getSlots().isEmpty());
 
         utterance = "this code is for test 1";
         float[] intentResult =
@@ -85,6 +100,7 @@ public class TensorflowNLUTest {
 
         assertNull(result.getError());
         assertEquals("describe_test", result.getIntent());
+        assertEquals(10.0, result.getConfidence());
         for (String slotName : slots.keySet()) {
             assertEquals(slots.get(slotName), result.getSlots().get(slotName));
         }

--- a/src/test/java/io/spokestack/spokestack/nlu/tensorflow/WordpieceTextEncoderTest.java
+++ b/src/test/java/io/spokestack/spokestack/nlu/tensorflow/WordpieceTextEncoderTest.java
@@ -1,22 +1,48 @@
 package io.spokestack.spokestack.nlu.tensorflow;
 
 import io.spokestack.spokestack.SpeechConfig;
+import io.spokestack.spokestack.nlu.NLUContext;
+import io.spokestack.spokestack.util.EventTracer;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class WordpieceTextEncoderTest {
     private static final String VOCAB_PATH = "src/test/resources/vocab.txt";
 
     @Test
-    public void encodeSingle() throws Exception {
+    public void loadErrors() throws InterruptedException {
+        SpeechConfig config = new SpeechConfig();
+        config.put("wordpiece-vocab-path", "invalid/path");
+        NLUContext context = new NLUContext(config);
+        AtomicBoolean loadError = new AtomicBoolean(false);
+        context.addTraceListener((level, message) -> {
+            if (level.equals(EventTracer.Level.ERROR)) {
+                loadError.set(true);
+            }
+        });
+        ControllableFactory factory = new ControllableFactory();
+
+        new WordpieceTextEncoder(config, context, factory);
+        factory.theOneThread.join();
+        assertTrue(loadError.get());
+    }
+
+    @Test
+    public void encodeSingle() {
         SpeechConfig config = new SpeechConfig();
         config.put("wordpiece-vocab-path", VOCAB_PATH);
-        WordpieceTextEncoder encoder = new WordpieceTextEncoder(config);
+        NLUContext context = new NLUContext(config);
+        WordpieceTextEncoder encoder =
+              new WordpieceTextEncoder(config, context);
 
         assertEquals(1, encoder.encodeSingle("the"));
         assertEquals(0, encoder.encodeSingle("tea"));
@@ -24,10 +50,12 @@ public class WordpieceTextEncoderTest {
     }
 
     @Test
-    public void encode() throws Exception {
+    public void encode() {
         SpeechConfig config = new SpeechConfig();
         config.put("wordpiece-vocab-path", VOCAB_PATH);
-        WordpieceTextEncoder encoder = new WordpieceTextEncoder(config);
+        NLUContext context = new NLUContext(config);
+        WordpieceTextEncoder encoder =
+              new WordpieceTextEncoder(config, context);
 
         String text = " ";
         EncodedTokens encoded = encoder.encode(text);
@@ -68,5 +96,15 @@ public class WordpieceTextEncoderTest {
         // a couple round trips to verify proper index tracking
         assertEquals("\"(these)\"", encoded.decodeRange(0, 2));
         assertEquals("\"(these)\" decisions", encoded.decodeRange(0, 9));
+    }
+
+    static class ControllableFactory implements ThreadFactory {
+        private Thread theOneThread;
+
+        @Override
+        public Thread newThread(@NotNull Runnable r) {
+            theOneThread = new Thread(r);
+            return theOneThread;
+        }
     }
 }

--- a/src/test/java/io/spokestack/spokestack/nlu/tensorflow/WordpieceTextEncoderTest.java
+++ b/src/test/java/io/spokestack/spokestack/nlu/tensorflow/WordpieceTextEncoderTest.java
@@ -1,0 +1,72 @@
+package io.spokestack.spokestack.nlu.tensorflow;
+
+import io.spokestack.spokestack.SpeechConfig;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class WordpieceTextEncoderTest {
+    private static final String VOCAB_PATH = "src/test/resources/vocab.txt";
+
+    @Test
+    public void encodeSingle() throws Exception {
+        SpeechConfig config = new SpeechConfig();
+        config.put("wordpiece-vocab-path", VOCAB_PATH);
+        WordpieceTextEncoder encoder = new WordpieceTextEncoder(config);
+
+        assertEquals(1, encoder.encodeSingle("the"));
+        assertEquals(0, encoder.encodeSingle("tea"));
+        assertEquals(0, encoder.encodeSingle("[UNK]"));
+    }
+
+    @Test
+    public void encode() throws Exception {
+        SpeechConfig config = new SpeechConfig();
+        config.put("wordpiece-vocab-path", VOCAB_PATH);
+        WordpieceTextEncoder encoder = new WordpieceTextEncoder(config);
+
+        String text = " ";
+        EncodedTokens encoded = encoder.encode(text);
+        List<Integer> expectedIds = new ArrayList<>();
+        assertEquals(expectedIds, encoded.getIds());
+
+        text = "I made the WORST decision.";
+        encoded = encoder.encode(text);
+        expectedIds = Arrays.asList(0, 0, 1, 2, 3, 4, 0);
+        assertEquals(expectedIds, encoded.getIds());
+
+        // if any part of the word isn't in the dictionary, the whole token
+        // gets the [UNK] id
+        // (not going to happen in practice, but this just exercises
+        // the tokenizer)
+        encoded = encoder.encode("the decisioner");
+        expectedIds = Arrays.asList(1, 0);
+        assertEquals(expectedIds, encoded.getIds());
+
+        encoded = encoder.encode("I made the WORST decisions.");
+        expectedIds = Arrays.asList(0, 0, 1, 2, 3, 4, 5, 0);
+        assertEquals(expectedIds, encoded.getIds());
+
+        encoded = encoder.encode("these s e decisions");
+        // "s" and "e" are not listed as whole tokens in the vocab
+        expectedIds = Arrays.asList(1, 5, 6, 0, 0, 3, 4, 5);
+        assertEquals(expectedIds, encoded.getIds());
+
+        text = "thé\t\tdecisions\n.";
+        encoded = encoder.encode(text);
+        expectedIds = Arrays.asList(1, 3, 4, 5, 0);
+        assertEquals(expectedIds, encoded.getIds());
+
+        encoded = encoder.encode("\"(these)\" decisions");
+        expectedIds = Arrays.asList(0, 0, 1, 5, 6, 0, 0, 3, 4, 5);
+        assertEquals(expectedIds, encoded.getIds());
+
+        // a couple round trips to verify proper index tracking
+        assertEquals("\"(these)\"", encoded.decodeRange(0, 2));
+        assertEquals("\"(these)\" decisions", encoded.decodeRange(0, 9));
+    }
+}

--- a/src/test/java/io/spokestack/spokestack/nlu/tensorflow/parsers/DigitsParserTest.java
+++ b/src/test/java/io/spokestack/spokestack/nlu/tensorflow/parsers/DigitsParserTest.java
@@ -1,0 +1,90 @@
+package io.spokestack.spokestack.nlu.tensorflow.parsers;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class DigitsParserTest {
+
+    @Test
+    public void parseErrors() {
+        DigitsParser parser = new DigitsParser();
+        HashMap<String, Object> metadata = new HashMap<>();
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            parser.parse(metadata, "invalid");
+        });
+
+        metadata.put("count", 10D);
+        assertThrows(IllegalArgumentException.class, () -> {
+            parser.parse(metadata, "123456789");
+        });
+
+        metadata.put("count", 1D);
+        assertThrows(IllegalArgumentException.class, () -> {
+            parser.parse(metadata, "thirty");
+        });
+    }
+
+    @Test
+    public void testParse() {
+        DigitsParser parser = new DigitsParser();
+        HashMap<String, Object> metadata = new HashMap<>();
+
+        // mod 20
+        assertEquals("1", parser.parse(metadata, " one"));
+        assertEquals("2", parser.parse(metadata, "two "));
+        assertEquals("3", parser.parse(metadata, " three "));
+        assertEquals("4", parser.parse(metadata, "  four  "));
+        assertEquals("5", parser.parse(metadata, "five"));
+        assertEquals("6", parser.parse(metadata, "six"));
+        assertEquals("7", parser.parse(metadata, "seven"));
+        assertEquals("8", parser.parse(metadata, "eight"));
+        assertEquals("9", parser.parse(metadata, "nine"));
+        assertEquals("10", parser.parse(metadata, "ten"));
+        assertEquals("11", parser.parse(metadata, "eleven"));
+        assertEquals("12", parser.parse(metadata, "twelve"));
+        assertEquals("13", parser.parse(metadata, "thirteen"));
+        assertEquals("14", parser.parse(metadata, "fourteen"));
+        assertEquals("15", parser.parse(metadata, "fifteen"));
+        assertEquals("16", parser.parse(metadata, "sixteen"));
+        assertEquals("17", parser.parse(metadata, "seventeen"));
+        assertEquals("18", parser.parse(metadata, "eighteen"));
+        assertEquals("19", parser.parse(metadata, "nineteen"));
+
+        // div 10
+        assertEquals("20", parser.parse(metadata, "twenty"));
+        assertEquals("3001", parser.parse(metadata, "thirty  zero   one"));
+        assertEquals("41", parser.parse(metadata, "forty one"));
+        assertEquals("52", parser.parse(metadata, "fifty-two"));
+        assertEquals("68", parser.parse(metadata, "sixty - eight"));
+        assertEquals("7010", parser.parse(metadata, "seventy ten"));
+
+        // hundreds
+        assertEquals("100", parser.parse(metadata, "one hundred"));
+        assertEquals("18003352211", parser.parse(metadata,
+              "one eight hundred three three five twenty-two eleven"));
+        assertEquals("18003352211", parser.parse(metadata, "18003352211"));
+
+        // thousands
+        assertEquals("2000", parser.parse(metadata, "two thousand"));
+        assertEquals("18003354000", parser.parse(metadata,
+              "one eight hundred three thirty-five four thousand"));
+
+        // homophones
+        assertEquals("0000", parser.parse(metadata, "zero oh oh owe"));
+        assertEquals("11", parser.parse(metadata, "one won"));
+        assertEquals("222", parser.parse(metadata, "two too to"));
+        assertEquals("444", parser.parse(metadata, "four for fore"));
+        assertEquals("666", parser.parse(metadata, "six sicks sics"));
+        assertEquals("88", parser.parse(metadata, "eight ate"));
+        assertEquals("1010", parser.parse(metadata, "ten tin"));
+
+        // mixed
+        assertEquals("012345667789", parser.parse(metadata,
+              "oh one 23 for five 66 seventy-seven ate 9"));
+    }
+}

--- a/src/test/java/io/spokestack/spokestack/nlu/tensorflow/parsers/IntegerParserTest.java
+++ b/src/test/java/io/spokestack/spokestack/nlu/tensorflow/parsers/IntegerParserTest.java
@@ -1,0 +1,50 @@
+package io.spokestack.spokestack.nlu.tensorflow.parsers;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class IntegerParserTest {
+
+    @Test
+    public void testParse() {
+        IntegerParser parser = new IntegerParser();
+        HashMap<String, Object> metadata = new HashMap<>();
+        assertThrows(IllegalArgumentException.class, () ->
+              parser.parse(metadata, "invalid"));
+        assertThrows(IllegalArgumentException.class, () ->
+              parser.parse(metadata, ""));
+
+        // out of range
+        metadata.put("range", Arrays.asList(1D, 11D));
+        assertThrows(IllegalArgumentException.class, () ->
+              parser.parse(metadata, "twelve"));
+        assertThrows(IllegalArgumentException.class, () ->
+              parser.parse(metadata, "12"));
+        assertThrows(IllegalArgumentException.class, () ->
+              parser.parse(metadata, "1000000000000"));
+
+        assertEquals(10, parser.parse(metadata, "Ten"));
+        assertEquals(10, parser.parse(metadata, "10"));
+
+        metadata.put("range", Arrays.asList(1D, 10000000D));
+
+        assertEquals(22, parser.parse(metadata, "twenty-two"));
+        assertEquals(22, parser.parse(metadata, "twenty two"));
+
+        assertEquals(1000000, parser.parse(metadata, "one million"));
+        assertEquals(1000000, parser.parse(metadata, "1000000"));
+
+        String text = "three thousand two hundred forty two";
+        assertEquals(3242, parser.parse(metadata, text));
+        text = "three thousand two hundred forty second";
+        assertEquals(3242, parser.parse(metadata, text));
+
+        assertEquals(13, parser.parse(metadata, "thirteen"));
+        assertEquals(13, parser.parse(metadata, "thirteenth"));
+    }
+}

--- a/src/test/java/io/spokestack/spokestack/nlu/tensorflow/parsers/SelsetParserTest.java
+++ b/src/test/java/io/spokestack/spokestack/nlu/tensorflow/parsers/SelsetParserTest.java
@@ -1,0 +1,52 @@
+package io.spokestack.spokestack.nlu.tensorflow.parsers;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Type;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class SelsetParserTest {
+    private static final String CONFIG_JSON =
+          "{\"selections\": ["
+                + "{\"name\": \"foo\", \"aliases\": [\"bar\"]}, "
+                + "{\"name\": \"other\", \"aliases\": []}"
+                + "]}";
+
+    private SelsetParser parser;
+    private HashMap<String, Object> metadata;
+
+    @Before
+    public void setup() {
+        parser = new SelsetParser();
+        Gson gson = new Gson();
+        Type type = new TypeToken<HashMap<String, Object>>(){}.getType();
+        metadata = gson.fromJson(CONFIG_JSON, type);
+    }
+
+    @Test
+    public void invalidParses() {
+        // bad config
+        HashMap<String, Object> emptyMeta = new HashMap<>();
+        assertThrows(IllegalArgumentException.class, () ->
+              parser.parse(emptyMeta, "foo"));
+
+        // invalid input
+        assertThrows(IllegalArgumentException.class, () ->
+              parser.parse(metadata, "invalid"));
+        assertThrows(IllegalArgumentException.class, () ->
+              parser.parse(metadata, ""));
+    }
+
+    @Test
+    public void validParses() {
+        assertEquals("foo", parser.parse(metadata, "foo"));
+        assertEquals("foo", parser.parse(metadata, "bar"));
+        assertEquals("other", parser.parse(metadata, "other"));
+    }
+}

--- a/src/test/resources/nlu.json
+++ b/src/test/resources/nlu.json
@@ -17,7 +17,8 @@
         },
         {
           "name": "test_num",
-          "type": "integer"
+          "type": "integer",
+          "facets": "{\"range\": [1, 10]}"
         }
       ]
     }

--- a/src/test/resources/nlu.json
+++ b/src/test/resources/nlu.json
@@ -1,0 +1,32 @@
+{
+  "intents": [
+    {
+      "name": "accept.proposal",
+      "slots": []
+    },
+    {
+      "name": "reject.proposal",
+      "slots": []
+    },
+    {
+      "name": "describe_test",
+      "slots": [
+        {
+          "name": "noun_phrase",
+          "type": "entity"
+        },
+        {
+          "name": "test_num",
+          "type": "integer"
+        }
+      ]
+    }
+  ],
+  "tags": [
+    "o",
+    "b_noun_phrase",
+    "i_noun_phrase",
+    "b_test_num",
+    "i_test_num"
+  ]
+}

--- a/src/test/resources/vocab.txt
+++ b/src/test/resources/vocab.txt
@@ -1,0 +1,7 @@
+[UNK]
+the
+worst
+decis
+##ion
+##s
+##e


### PR DESCRIPTION
This initial client for the NLU API enables on-device
intent classification and slot recognition via a
pretrained TensorFlow Lite model, metadata, and vocabulary
supplied by the app.

ASR results (or any text) are encoded using the Wordpiece
scheme from Google's BERT model then fed to the TFLite model;
the resulting predictions are parsed into actionable intents and
typed slots using the supplied JSON metadata.

Slot parsers are provided for integer, digits, selset, and entity slots,
and custom slot parsers can be registered by class name.

There is an item or two I'd like to adopt from the iOS interface, so I've
marked this don't merge, but I figured I'd post it now so that review
could start.