### PR TITLE
Fix: Allow slot tags to be discontinuous

### DIFF
--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TFNLUOutput.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TFNLUOutput.java
@@ -77,7 +77,13 @@ final class TFNLUOutput {
             String value = encoded.decodeRange(slotRange.getKey(),
                   slotRange.getValue(), true);
             String slotName = tagLabels[slotRange.getKey()].substring(2);
-            slots.put(slotName, value);
+            String curValue = slots.get(slotName);
+            if (curValue != null) {
+                curValue += " " + value;
+                slots.put(slotName, curValue);
+            } else {
+                slots.put(slotName, value);
+            }
         }
         return slots;
     }


### PR DESCRIPTION
After observing results like this in the wild, I decided to make the Android behavior for slots tagged more than once in a classification match the iOS behavior.