### PR TITLE
Support new slot features

### DIFF
--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/Metadata.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/Metadata.java
@@ -1,6 +1,7 @@
 package io.spokestack.spokestack.nlu.tensorflow;
 
 import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
 
 import java.lang.reflect.Type;
@@ -13,8 +14,13 @@ import java.util.Map;
  * translate the model's raw outputs into actionable intent and slot data.
  */
 final class Metadata {
-    private Intent[] intents;
-    private String[] tags;
+    private final Intent[] intents;
+    private final String[] tags;
+
+    Metadata(Intent[] intentArr, String[] tagArr) {
+        this.intents = intentArr;
+        this.tags = tagArr;
+    }
 
     /**
      * @return the metadata for all intents associated with this model.
@@ -31,21 +37,31 @@ final class Metadata {
     }
 
     /**
-     * An intent definition. In model metadata, an intent consists of a name
-     * and a collection of slots recognized along with the intent.
+     * An intent definition. In model metadata, an intent consists of a name and
+     * a collection of slots recognized along with the intent.
      */
     static class Intent {
-        private String name;
-        private Slot[] slots;
+        @SerializedName("implicit_slots")
+        private final Slot[] implicitSlots;
+        private final String name;
+        private final Slot[] slots;
         private Map<String, Slot> slotIndex;
 
-        Intent(String slotName, Slot[] slotMetas) {
-            this.name = slotName;
+        Intent(String intentName, Slot[] slotMetas, Slot[] implicitSlotMetas) {
+            this.name = intentName;
             this.slots = slotMetas;
+            this.implicitSlots = implicitSlotMetas;
         }
 
         public String getName() {
             return name;
+        }
+
+        public Slot[] getImplicitSlots() {
+            if (implicitSlots != null) {
+                return implicitSlots;
+            }
+            return new Slot[0];
         }
 
         public Slot getSlot(String slotName) {
@@ -65,30 +81,49 @@ final class Metadata {
      * type.
      *
      * <p>
-     * For example, a slot with the "selset" type will list individual
-     * {@code selections} that contain aliases for each value. An "integer"
-     * slot may contain information about the range of values it should
-     * consider valid.
+     * For example, a slot with the "selset" type will list individual {@code
+     * selections} that contain aliases for each value. An "integer" slot may
+     * contain information about the range of values it should consider valid.
+     * </p>
+     *
+     * <p>
+     * The {@code value} field will only be present for implicit slots.
      * </p>
      */
     static class Slot {
-        private String name;
-        private String type;
-        private String facets;
+        @SerializedName("capture_name")
+        private final String captureName;
+        private final String name;
+        private final String type;
+        private final Object value;
+        private final String facets;
         private Map<String, Object> parsedFacets;
 
-        Slot(String slotName, String slotType, String slotFacets) {
-            this.name = slotName;
-            this.type = slotType;
-            this.facets = slotFacets;
+        Slot(String sName,
+             String sCaptureName,
+             String sType,
+             String sFacets,
+             Object sValue) {
+            this.name = sName;
+            this.captureName = sCaptureName;
+            this.type = sType;
+            this.value = sValue;
+            this.facets = sFacets;
         }
 
         public String getName() {
+            if (captureName != null) {
+                return captureName;
+            }
             return name;
         }
 
         public String getType() {
             return type;
+        }
+
+        public Object getValue() {
+            return value;
         }
 
         public Map<String, Object> getFacets() {

--- a/src/test/java/io/spokestack/spokestack/nlu/tensorflow/TFNLUOutputTest.java
+++ b/src/test/java/io/spokestack/spokestack/nlu/tensorflow/TFNLUOutputTest.java
@@ -1,0 +1,166 @@
+package io.spokestack.spokestack.nlu.tensorflow;
+
+import com.google.gson.Gson;
+import com.google.gson.stream.JsonReader;
+import io.spokestack.spokestack.SpeechConfig;
+import io.spokestack.spokestack.nlu.NLUContext;
+import io.spokestack.spokestack.nlu.Slot;
+import io.spokestack.spokestack.nlu.tensorflow.parsers.IdentityParser;
+import io.spokestack.spokestack.nlu.tensorflow.parsers.IntegerParser;
+import io.spokestack.spokestack.util.Tuple;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.Reader;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class TFNLUOutputTest {
+
+    private Metadata metadata;
+    private TFNLUOutput outputParser;
+
+    @Before
+    public void before() throws FileNotFoundException {
+        Gson gson = new Gson();
+        Reader reader = new FileReader("src/test/resources/nlu.json");
+        JsonReader jsonReader = new JsonReader(reader);
+        metadata = gson.fromJson(jsonReader, Metadata.class);
+        outputParser = new TFNLUOutput(metadata);
+    }
+
+    @Test
+    public void getIntent() {
+        ByteBuffer output = ByteBuffer
+              .allocateDirect(4 * metadata.getIntents().length * 4)
+              .order(ByteOrder.nativeOrder());
+        output.rewind();
+        for (Float val : Arrays.asList(0.0f, 0.0f, 0.0f, 10.0f)) {
+            output.putFloat(val);
+        }
+        output.rewind();
+
+        Metadata.Intent intent = getTargetIntent("slot_features");
+
+        Tuple<Metadata.Intent, Float> result = outputParser.getIntent(output);
+
+        assertEquals(intent.getName(), result.first().getName());
+        assertEquals((Float) 10.0f, result.second());
+    }
+
+    @Test
+    public void getSlots() {
+        ByteBuffer output = ByteBuffer
+              .allocateDirect(5 * metadata.getTags().length * 4)
+              .order(ByteOrder.nativeOrder());
+        output.rewind();
+
+        List<Float> tagPosteriors =
+              setTagPosteriors(
+                    Arrays.asList("o", "b_feature_1", "o", "o", "b_feature_2"));
+        for (Float val : tagPosteriors) {
+            output.putFloat(val);
+        }
+        output.rewind();
+
+        Map<String, String> expected = new HashMap<>();
+        expected.put("feature_1", "utterance");
+        expected.put("feature_2", "2");
+
+        NLUContext context = new NLUContext(new SpeechConfig());
+        String utterance = "an utterance for test 2";
+        String[] split = utterance.split(" ");
+        EncodedTokens encoded = new EncodedTokens(split);
+        List<Integer> indices = new ArrayList<>();
+        for (int i = 0; i < split.length; i++) {
+            indices.add(i);
+        }
+        encoded.addTokenIds(indices);
+        encoded.setOriginalIndices(indices);
+
+        Map<String, String> result =
+              outputParser.getSlots(context, encoded, output);
+
+        assertEquals(expected, result);
+    }
+
+    private List<Float> setTagPosteriors(List<String> tags) {
+        List<Float> posteriors = new ArrayList<>();
+        for (String desired : tags) {
+            for (String tag : metadata.getTags()) {
+                if (tag.equals(desired)) {
+                    posteriors.add(10.0f);
+                } else {
+                    posteriors.add(0.0f);
+                }
+            }
+        }
+        return posteriors;
+    }
+
+    @Test
+    public void parseSlots() {
+        // no slots, null implicit_slots
+        Metadata.Intent intent = getTargetIntent("accept.proposal");
+
+        TFNLUOutput outputParser = new TFNLUOutput(metadata);
+        outputParser.registerSlotParsers(getSlotParsers());
+
+        Map<String, Slot> expected = new HashMap<>();
+        Map<String, Slot> result =
+              outputParser.parseSlots(intent, new HashMap<>());
+        assertEquals(expected, result);
+
+        intent = getTargetIntent("slot_features");
+
+        Map<String, String> slotValues = new HashMap<>();
+        slotValues.put("feature_2", "9");
+
+        expected = new HashMap<>();
+        Slot implicitSlot = new Slot("feature_1", "default", "default");
+        // no value is present in the output, so the implicit value is used
+        expected.put("feature_1", implicitSlot);
+        // note the name override
+        Slot captureNameSlot = new Slot("test_num", "9", 9);
+        expected.put("test_num", captureNameSlot);
+
+        result = outputParser.parseSlots(intent, slotValues);
+        assertEquals(expected, result);
+
+        // explicit values override implicit ones
+        slotValues = new HashMap<>();
+        slotValues.put("feature_1", "overridden");
+
+        expected = new HashMap<>();
+        implicitSlot = new Slot("feature_1", "overridden", "overridden");
+        expected.put("feature_1", implicitSlot);
+
+        result = outputParser.parseSlots(intent, slotValues);
+        assertEquals(expected, result);
+    }
+
+    private Metadata.Intent getTargetIntent(String name) {
+        for (Metadata.Intent in : metadata.getIntents()) {
+            if (in.getName().equals(name)) {
+                return in;
+            }
+        }
+        return null;
+    }
+
+    private Map<String, SlotParser> getSlotParsers() {
+        Map<String, SlotParser> parsers = new HashMap<>();
+        parsers.put("integer", new IntegerParser());
+        parsers.put("entity", new IdentityParser());
+        return parsers;
+    }
+}

--- a/src/test/resources/nlu.json
+++ b/src/test/resources/nlu.json
@@ -21,6 +21,28 @@
           "facets": "{\"range\": [1, 10]}"
         }
       ]
+    },
+    {
+      "name": "slot_features",
+      "implicit_slots": [
+        {
+          "name": "feature_1",
+          "type": "entity",
+          "value": "default"
+        }
+      ],
+      "slots": [
+        {
+          "name": "feature_1",
+          "type": "entity"
+        },
+        {
+          "name": "feature_2",
+          "capture_name": "test_num",
+          "type": "integer",
+          "facets": "{\"range\": [1, 10]}"
+        }
+      ]
     }
   ],
   "tags": [
@@ -28,6 +50,10 @@
     "b_noun_phrase",
     "i_noun_phrase",
     "b_test_num",
-    "i_test_num"
+    "i_test_num",
+    "b_feature_1",
+    "i_feature_1",
+    "b_feature_2",
+    "i_feature_2"
   ]
 }


### PR DESCRIPTION
This adds support for new features for domain-specific NLU models. Changes are backwards compatible, so there should be no disruption to operation with current models.

- implicit slots at the intent level, which can be overridden by
  concrete values in the model output
- name changes for slots specified in the metadata via capture_name