### PR TITLE
Unknown slot handling

### DIFF
--- a/src/main/java/io/spokestack/spokestack/nlu/NLUContext.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/NLUContext.java
@@ -94,6 +94,16 @@ public final class NLUContext {
     }
 
     /**
+     * Traces a warning level message.
+     *
+     * @param format trace message format string
+     * @param params trace message format parameters
+     */
+    public void traceWarn(String format, Object... params) {
+        trace(EventTracer.Level.WARN, format, params);
+    }
+
+    /**
      * Traces an error level message.
      *
      * @param format trace message format string

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TFNLUOutput.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TFNLUOutput.java
@@ -135,24 +135,28 @@ final class TFNLUOutput {
      * Parse raw slot values into objects according to the slot parsers
      * registered for this model.
      *
+     * @param context  The context used to communicate trace events.
      * @param intent     The intent for which slots are being parsed.
      * @param slotValues A map of slot name to raw string value output from the
      *                   model.
      * @return A map of slot name to parsed slot values.
      */
     public Map<String, Slot> parseSlots(
+          @NonNull NLUContext context,
           @NonNull Metadata.Intent intent,
           @NonNull Map<String, String> slotValues) {
         Map<String, Slot> parsed = parseImplicitSlots(intent);
         for (String slotName : slotValues.keySet()) {
             Metadata.Slot metaSlot = intent.getSlot(slotName);
+            String slotVal = slotValues.get(slotName);
             if (metaSlot == null) {
-                String message = String.format("no %s slot in %s intent",
+                context.traceWarn("no %s slot in %s intent",
                       slotName, intent.getName());
-                throw new IllegalArgumentException(message);
+                Slot defaultParse = new Slot(slotName, slotVal, slotVal);
+                parsed.put(slotName, defaultParse);
+                continue;
             }
-            Slot parsedValue =
-                  parseSlotValue(metaSlot, slotValues.get(slotName));
+            Slot parsedValue = parseSlotValue(metaSlot, slotVal);
             parsed.put(parsedValue.getName(), parsedValue);
         }
 

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TensorflowNLU.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TensorflowNLU.java
@@ -220,7 +220,8 @@ public final class TensorflowNLU implements NLUService {
               this.context,
               encoded,
               this.nluModel.outputs(1));
-        Map<String, Slot> parsedSlots = outputParser.parseSlots(intent, slots);
+        Map<String, Slot> parsedSlots =
+              outputParser.parseSlots(this.context, intent, slots);
         nluContext.traceDebug("Slots: %s", parsedSlots.toString());
 
         return new NLUResult.Builder(utterance)

--- a/src/test/resources/nlu.json
+++ b/src/test/resources/nlu.json
@@ -1,11 +1,11 @@
 {
   "intents": [
     {
-      "name": "accept.proposal",
+      "name": "accept",
       "slots": []
     },
     {
-      "name": "reject.proposal",
+      "name": "reject",
       "slots": []
     },
     {


### PR DESCRIPTION
Instead of throwing an error, if a slot not correlated with the predicted intent is tagged in an utterance, its raw value will be returned instead of the entire classification failing with an error.

This is the change we talked about the other day, which makes sense given our current tagger setup. I did want to retain this as a warning-level log, which necessitated a bit of extra machinery.

