### PR TITLE
Fix: Surface TTS errors to the client via events

### DIFF
--- a/src/main/java/io/spokestack/spokestack/tts/SpokestackSynthesisResponse.java
+++ b/src/main/java/io/spokestack/spokestack/tts/SpokestackSynthesisResponse.java
@@ -7,6 +7,7 @@ package io.spokestack.spokestack.tts;
 public class SpokestackSynthesisResponse {
 
     private ResponseData data;
+    private ResponseError[] errors;
 
     /**
      * @return The URL where synthesized audio can be streamed.
@@ -31,6 +32,23 @@ public class SpokestackSynthesisResponse {
     }
 
     /**
+     * @return A concatenation of all error messages from the response.
+     */
+    public String getError() {
+        if (errors == null || errors.length == 0) {
+            return null;
+        }
+        StringBuilder errorBuilder = new StringBuilder();
+        for (int i = 0; i < errors.length; i++) {
+            if (i > 0) {
+                errorBuilder.append("; ");
+            }
+            errorBuilder.append(errors[i].message);
+        }
+        return errorBuilder.toString();
+    }
+
+    /**
      * Wrapper class used for deserializing synthesis responses.
      */
     private static class ResponseData {
@@ -44,5 +62,12 @@ public class SpokestackSynthesisResponse {
      */
     private static class ResponseMethod {
         private String url;
+    }
+
+    /**
+     * Wrapper class used for deserializing GraphQL errors.
+     */
+    private static class ResponseError {
+        private String message;
     }
 }

--- a/src/main/java/io/spokestack/spokestack/tts/SpokestackTTSService.java
+++ b/src/main/java/io/spokestack/spokestack/tts/SpokestackTTSService.java
@@ -91,14 +91,18 @@ public final class SpokestackTTSService extends TTSService {
     private class SpokestackCallback extends TTSCallback {
         @Override
         public void onFailure(@NonNull Call call, IOException e) {
-            TTSEvent event = new TTSEvent(TTSEvent.Type.ERROR);
-            event.setError(e);
-            dispatch(event);
+            raiseError(e);
         }
 
         @Override
         public void onError(String message) {
-            // no-op; we're throwing the error directly
+            raiseError(new IOException(message));
+        }
+
+        private void raiseError(Exception error) {
+            TTSEvent event = new TTSEvent(TTSEvent.Type.ERROR);
+            event.setError(error);
+            dispatch(event);
         }
 
         @Override


### PR DESCRIPTION
Thanks for the bug reports, @noelweichbrodt. `null` TTS audio URLs should no longer be possible, and both GraphQL and HTTP errors should be surfaced as expected via `TTSEvent.Type.ERROR` events.