### PR TITLE
Feature: Slot output changes

### DIFF
--- a/src/main/java/io/spokestack/spokestack/nlu/Slot.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/Slot.java
@@ -61,8 +61,13 @@ public final class Slot {
         }
         Slot slot = (Slot) o;
         return getName().equals(slot.getName())
-              && getRawValue().equals(slot.getRawValue())
-              && getValue().equals(slot.getValue());
+              && nullOrEqual(getRawValue(), slot.getRawValue())
+              && nullOrEqual(getValue(), slot.getValue());
+    }
+
+    private boolean nullOrEqual(Object obj1, Object obj2) {
+        return (obj1 == null && obj2 == null)
+            || (obj1 != null && obj1.equals(obj2));
     }
 
     @Override
@@ -79,4 +84,3 @@ public final class Slot {
               + '}';
     }
 }
-

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/Metadata.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/Metadata.java
@@ -45,7 +45,6 @@ final class Metadata {
         private final Slot[] implicitSlots;
         private final String name;
         private final Slot[] slots;
-        private Map<String, Slot> slotIndex;
 
         Intent(String intentName, Slot[] slotMetas, Slot[] implicitSlotMetas) {
             this.name = intentName;
@@ -64,14 +63,8 @@ final class Metadata {
             return new Slot[0];
         }
 
-        public Slot getSlot(String slotName) {
-            if (slotIndex == null) {
-                slotIndex = new HashMap<>();
-                for (Slot slot : slots) {
-                    slotIndex.put(slot.name, slot);
-                }
-            }
-            return slotIndex.get(slotName);
+        public Slot[] getSlots() {
+            return slots;
         }
     }
 
@@ -111,10 +104,14 @@ final class Metadata {
             this.facets = sFacets;
         }
 
-        public String getName() {
+        public String getCaptureName() {
             if (captureName != null) {
                 return captureName;
             }
+            return name;
+        }
+
+        public String getName() {
             return name;
         }
 

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TensorflowNLU.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TensorflowNLU.java
@@ -230,8 +230,7 @@ public final class TensorflowNLU implements NLUService {
               nluContext,
               encoded,
               this.nluModel.outputs(1));
-        Map<String, Slot> parsedSlots =
-              outputParser.parseSlots(nluContext, intent, slots);
+        Map<String, Slot> parsedSlots = outputParser.parseSlots(intent, slots);
         nluContext.traceDebug("Slots: %s", parsedSlots.toString());
 
         return new NLUResult.Builder(utterance)


### PR DESCRIPTION
These are the changes we talked about earlier today. I kept compatibility with the implicit slot and capture name features because they were already here, but we're not currently using them; if they're not in iOS yet, compatibility with the main features here doesn't require adding them:

- Return slots with null values for slots declared by the
  metadata but absent from the utterance
- Silently ignore slots spuriously detected by the model