### PR TITLE
Fix: null slot values instead of errors

### DIFF
--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TFNLUOutput.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TFNLUOutput.java
@@ -152,7 +152,7 @@ final class TFNLUOutput {
             if (slotVal == null) {
                 String captureName = metaSlot.getCaptureName();
                 if (!parsed.containsKey(captureName)) {
-                    Slot emptySlot = new Slot(captureName, null, null);
+                    Slot emptySlot = new Slot(captureName, slotVal, null);
                     parsed.put(captureName, emptySlot);
                 }
                 // else leave the existing (implicit) slot alone

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/parsers/DigitsParser.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/parsers/DigitsParser.java
@@ -109,8 +109,7 @@ public final class DigitsParser implements SlotParser {
             || (numDigits != null && resultBuilder.length() == numDigits)) {
             return resultBuilder.toString();
         }
-        throw new IllegalArgumentException(
-              "invalid digit string: " + resultBuilder.toString());
+        return null;
     }
 
     private String parseSingle(String numStr, String next) {

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/parsers/IntegerParser.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/parsers/IntegerParser.java
@@ -117,23 +117,27 @@ public final class IntegerParser implements SlotParser {
                 int parsed = Integer.parseInt(token);
                 parsedInts.add(parsed);
             } catch (NumberFormatException nfe) {
-                parseReduce(token, parsedInts);
+                List<Integer> reduced = parseReduce(token, parsedInts);
+                if (reduced == null) {
+                    return null;
+                }
             }
         }
         int result = sum(parsedInts);
         if (isInRange(result, range)) {
             return result;
         }
-        throw new IllegalArgumentException("number out of range: " + result);
+        return null;
     }
 
-    private void parseReduce(String numStr, List<Integer> soFar) {
+    private List<Integer> parseReduce(String numStr, List<Integer> soFar) {
         String toParse = numStr;
         if (toParse.endsWith("th")) {
             toParse = toParse.substring(0, toParse.length() - 2);
         }
         if (!WORD_TO_NUM.containsKey(toParse)) {
-            throw new IllegalArgumentException("Invalid integer: " + toParse);
+            // invalid number, but don't throw an error
+            return null;
         }
 
         if (MULTIPLIERS.containsKey(toParse)) {
@@ -143,6 +147,7 @@ public final class IntegerParser implements SlotParser {
         } else {
             soFar.add(WORD_TO_NUM.get(toParse));
         }
+        return soFar;
     }
 
     private List<Integer> collapse(int multiplier, List<Integer> soFar) {
@@ -160,7 +165,7 @@ public final class IntegerParser implements SlotParser {
         return collapsed;
     }
 
-    private int sum(List<Integer> parsed) {
+    private Integer sum(List<Integer> parsed) {
         int sum = 0;
         for (Integer num : parsed) {
             sum += num;

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/parsers/SelsetParser.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/parsers/SelsetParser.java
@@ -28,7 +28,7 @@ public final class SelsetParser implements SlotParser {
         }
 
         if (selections == null) {
-            throw new IllegalArgumentException("invalid selset facets");
+            return null;
         }
 
         String normalized = rawValue.toLowerCase();
@@ -45,6 +45,6 @@ public final class SelsetParser implements SlotParser {
                 }
             }
         }
-        throw new IllegalArgumentException("invalid alias: " + rawValue);
+        return null;
     }
 }

--- a/src/test/java/io/spokestack/spokestack/nlu/tensorflow/parsers/DigitsParserTest.java
+++ b/src/test/java/io/spokestack/spokestack/nlu/tensorflow/parsers/DigitsParserTest.java
@@ -4,8 +4,7 @@ import org.junit.Test;
 
 import java.util.HashMap;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DigitsParserTest {
 
@@ -14,19 +13,13 @@ public class DigitsParserTest {
         DigitsParser parser = new DigitsParser();
         HashMap<String, Object> metadata = new HashMap<>();
 
-        assertThrows(IllegalArgumentException.class, () -> {
-            parser.parse(metadata, "invalid");
-        });
+        assertNull(parser.parse(metadata, "invalid"));
 
         metadata.put("count", 10D);
-        assertThrows(IllegalArgumentException.class, () -> {
-            parser.parse(metadata, "123456789");
-        });
+        assertNull(parser.parse(metadata, "123456789"));
 
         metadata.put("count", 1D);
-        assertThrows(IllegalArgumentException.class, () -> {
-            parser.parse(metadata, "thirty");
-        });
+        assertNull(parser.parse(metadata, "thirty"));
     }
 
     @Test

--- a/src/test/java/io/spokestack/spokestack/nlu/tensorflow/parsers/IntegerParserTest.java
+++ b/src/test/java/io/spokestack/spokestack/nlu/tensorflow/parsers/IntegerParserTest.java
@@ -5,8 +5,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.HashMap;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class IntegerParserTest {
 
@@ -14,19 +13,14 @@ public class IntegerParserTest {
     public void testParse() {
         IntegerParser parser = new IntegerParser();
         HashMap<String, Object> metadata = new HashMap<>();
-        assertThrows(IllegalArgumentException.class, () ->
-              parser.parse(metadata, "invalid"));
-        assertThrows(IllegalArgumentException.class, () ->
-              parser.parse(metadata, ""));
+        assertNull(parser.parse(metadata, "invalid"));
+        assertNull(parser.parse(metadata, ""));
 
         // out of range
         metadata.put("range", Arrays.asList(1D, 11D));
-        assertThrows(IllegalArgumentException.class, () ->
-              parser.parse(metadata, "twelve"));
-        assertThrows(IllegalArgumentException.class, () ->
-              parser.parse(metadata, "12"));
-        assertThrows(IllegalArgumentException.class, () ->
-              parser.parse(metadata, "1000000000000"));
+        assertNull(parser.parse(metadata, "twelve"));
+        assertNull(parser.parse(metadata, "12"));
+        assertNull(parser.parse(metadata, "1000000000000"));
 
         assertEquals(10, parser.parse(metadata, "Ten"));
         assertEquals(10, parser.parse(metadata, "10"));

--- a/src/test/java/io/spokestack/spokestack/nlu/tensorflow/parsers/SelsetParserTest.java
+++ b/src/test/java/io/spokestack/spokestack/nlu/tensorflow/parsers/SelsetParserTest.java
@@ -8,8 +8,7 @@ import org.junit.Test;
 import java.lang.reflect.Type;
 import java.util.HashMap;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SelsetParserTest {
     private static final String CONFIG_JSON =
@@ -33,14 +32,11 @@ public class SelsetParserTest {
     public void invalidParses() {
         // bad config
         HashMap<String, Object> emptyMeta = new HashMap<>();
-        assertThrows(IllegalArgumentException.class, () ->
-              parser.parse(emptyMeta, "foo"));
+        assertNull(parser.parse(emptyMeta, "foo"));
 
         // invalid input
-        assertThrows(IllegalArgumentException.class, () ->
-              parser.parse(metadata, "invalid"));
-        assertThrows(IllegalArgumentException.class, () ->
-              parser.parse(metadata, ""));
+        assertNull(parser.parse(metadata, "invalid"));
+        assertNull(parser.parse(metadata, ""));
     }
 
     @Test


### PR DESCRIPTION
This change brings spokestack-android into line with the other platform libraries in returning an empty slot value instead of throwing an exception if an error is encountered during parsing.