### PR TITLE
Fix: Microphone sharing for Android ASR

### DIFF
--- a/src/main/java/io/spokestack/spokestack/ActivationTimeout.java
+++ b/src/main/java/io/spokestack/spokestack/ActivationTimeout.java
@@ -48,9 +48,9 @@ public final class ActivationTimeout implements SpeechProcessor {
      */
     public ActivationTimeout(SpeechConfig config) {
         int frameWidth = config.getInteger("frame-width");
-        this.minActive = config .getInteger("active-min", DEFAULT_ACTIVE_MIN)
+        this.minActive = config.getInteger("active-min", DEFAULT_ACTIVE_MIN)
               / frameWidth;
-        this.maxActive = config .getInteger("active-max", DEFAULT_ACTIVE_MAX)
+        this.maxActive = config.getInteger("active-max", DEFAULT_ACTIVE_MAX)
               / frameWidth;
     }
 
@@ -66,7 +66,7 @@ public final class ActivationTimeout implements SpeechProcessor {
     }
 
     private void deactivate(SpeechContext context) {
-        this.activeLength = 0;
+        reset();
         context.setActive(false);
     }
 

--- a/src/main/java/io/spokestack/spokestack/SpeechContext.java
+++ b/src/main/java/io/spokestack/spokestack/SpeechContext.java
@@ -53,6 +53,7 @@ public final class SpeechContext {
     private Deque<ByteBuffer> buffer;
     private boolean speech;
     private boolean active;
+    private boolean managed;
     private String transcript = "";
     private double confidence;
     private Throwable error;
@@ -144,6 +145,24 @@ public final class SpeechContext {
             dispatch(Event.DEACTIVATE);
         }
         return this;
+    }
+
+    /**
+     * @return whether the context is being managed externally.
+     */
+    public boolean isManaged() {
+        return managed;
+    }
+
+    /**
+     * signals whether the speech context is being externally managed (audio is
+     * not being read from the microphone by Spokestack's speech pipeline).
+     *
+     * @param value {@code true} if audio is being managed by an external
+     *                component.
+     */
+    public void setManaged(boolean value) {
+        this.managed = value;
     }
 
     /** @return the current speech transcript. */

--- a/src/main/java/io/spokestack/spokestack/SpeechInput.java
+++ b/src/main/java/io/spokestack/spokestack/SpeechInput.java
@@ -19,8 +19,10 @@ import java.nio.ByteBuffer;
 public interface SpeechInput extends AutoCloseable {
     /**
      * reads a set of samples into a frame buffer.
+     *
+     * @param context the current speech context
      * @param frame the frame buffer to fill
      * @throws Exception on error
      */
-    void read(ByteBuffer frame) throws Exception;
+    void read(SpeechContext context, ByteBuffer frame) throws Exception;
 }

--- a/src/main/java/io/spokestack/spokestack/SpeechPipeline.java
+++ b/src/main/java/io/spokestack/spokestack/SpeechPipeline.java
@@ -224,12 +224,14 @@ public final class SpeechPipeline implements AutoCloseable {
             this.context.getBuffer().addLast(frame);
 
             // fill the frame from the input
-            this.input.read(frame);
+            this.input.read(this.context, frame);
 
             // dispatch the frame to the stages
-            for (SpeechProcessor stage : this.stages) {
-                frame.rewind();
-                stage.process(this.context, frame);
+            if (!this.context.isManaged()) {
+                for (SpeechProcessor stage : this.stages) {
+                    frame.rewind();
+                    stage.process(this.context, frame);
+                }
             }
         } catch (Exception e) {
             raiseError(e);

--- a/src/main/java/io/spokestack/spokestack/android/MicrophoneInput.java
+++ b/src/main/java/io/spokestack/spokestack/android/MicrophoneInput.java
@@ -6,6 +6,7 @@ import android.media.AudioFormat;
 import android.media.AudioRecord;
 import android.media.MediaRecorder.AudioSource;
 
+import io.spokestack.spokestack.SpeechContext;
 import io.spokestack.spokestack.SpeechInput;
 import io.spokestack.spokestack.SpeechConfig;
 
@@ -68,9 +69,10 @@ public final class MicrophoneInput implements SpeechInput {
 
     /**
      * reads a frame from the microphone.
+     * @param context the current speech context
      * @param frame the frame buffer to fill
      */
-    public void read(ByteBuffer frame) {
+    public void read(SpeechContext context, ByteBuffer frame) {
         int read = this.recorder.read(frame, frame.capacity());
         if (read != frame.capacity())
             throw new IllegalStateException();

--- a/src/main/java/io/spokestack/spokestack/android/NoInput.java
+++ b/src/main/java/io/spokestack/spokestack/android/NoInput.java
@@ -1,0 +1,36 @@
+package io.spokestack.spokestack.android;
+
+import io.spokestack.spokestack.SpeechConfig;
+import io.spokestack.spokestack.SpeechContext;
+import io.spokestack.spokestack.SpeechInput;
+
+import java.nio.ByteBuffer;
+
+/**
+ * An empty input class that does not read from an audio source. Used as a
+ * placeholder in the pipeline when no wakeword is needed, and another component
+ * needs to control the microphone to perform ASR.
+ */
+public final class NoInput implements SpeechInput {
+
+    /**
+     * initializes a new empty SpeechInput.
+     *
+     * @param config speech pipeline configuration
+     */
+    public NoInput(SpeechConfig config) {
+    }
+
+    /**
+     * simulates reading an frame. actually does nothing.
+     *
+     * @param context the current speech context
+     * @param frame   the frame buffer to fill
+     */
+    public void read(SpeechContext context, ByteBuffer frame) {
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/src/main/java/io/spokestack/spokestack/android/PreASRMicrophoneInput.java
+++ b/src/main/java/io/spokestack/spokestack/android/PreASRMicrophoneInput.java
@@ -1,0 +1,104 @@
+package io.spokestack.spokestack.android;
+
+import android.media.AudioFormat;
+import android.media.AudioRecord;
+import android.media.MediaRecorder.AudioSource;
+import io.spokestack.spokestack.SpeechConfig;
+import io.spokestack.spokestack.SpeechContext;
+import io.spokestack.spokestack.SpeechInput;
+
+import java.nio.ByteBuffer;
+
+/**
+ * A variant of {@link MicrophoneInput} that releases its internal {@link
+ * AudioRecord} when ASR is activated to avoid microphone conflicts.
+ *
+ *
+ * <p>
+ * This class uses the configured sample rate and always reads single-chanel
+ * 16-bit PCM samples.
+ * </p>
+ */
+public final class PreASRMicrophoneInput implements SpeechInput {
+    private AudioRecord recorder;
+    private int sampleRate;
+    private int bufferSize;
+    private boolean recording;
+
+    /**
+     * initializes a new microphone instance and opens the audio recorder.
+     *
+     * @param config speech pipeline configuration
+     */
+    public PreASRMicrophoneInput(SpeechConfig config) {
+        this.sampleRate = config.getInteger("sample-rate");
+        this.bufferSize = AudioRecord.getMinBufferSize(
+              sampleRate,
+              AudioFormat.CHANNEL_IN_MONO,
+              AudioFormat.ENCODING_PCM_16BIT
+        );
+    }
+
+    /**
+     * @return the current {@code AudioRecord} instance. Used for testing.
+     */
+    AudioRecord getRecorder() {
+        return this.recorder;
+    }
+
+    /**
+     * Releases the resources associated with the microphone.
+     */
+    public void close() {
+        if (this.recorder != null) {
+            this.recorder.release();
+            this.recorder = null;
+        }
+    }
+
+    /**
+     * Reads a frame from the microphone if the pipeline is inactive. When the
+     * pipeline is activated, the microphone resource is released, and the
+     * speech context is flagged as being externally managed. The ASR component
+     * is expected to deactivate the pipeline to signal that Spokestack can
+     * recapture the microphone.
+     *
+     * @param context the current speech context
+     * @param frame   the frame buffer to fill
+     */
+    public void read(SpeechContext context, ByteBuffer frame) {
+        if (context.isActive()) {
+            stopRecording(context);
+        } else {
+            if (!this.recording) {
+                startRecording(context);
+            }
+            int read = this.recorder.read(frame, frame.capacity());
+            if (read != frame.capacity()) {
+                throw new IllegalStateException();
+            }
+        }
+    }
+
+    private void stopRecording(SpeechContext context) {
+        if (this.recorder != null) {
+            this.recorder.release();
+            this.recorder = null;
+            context.setManaged(true);
+        }
+        this.recording = false;
+    }
+
+    private void startRecording(SpeechContext context) {
+        this.recorder = new AudioRecord(
+              AudioSource.VOICE_RECOGNITION,
+              this.sampleRate,
+              AudioFormat.CHANNEL_IN_MONO,
+              AudioFormat.ENCODING_PCM_16BIT,
+              this.bufferSize
+        );
+        context.setManaged(false);
+        this.recorder.startRecording();
+        this.recording = true;
+    }
+}

--- a/src/main/java/io/spokestack/spokestack/android/SpeechRecognizerError.java
+++ b/src/main/java/io/spokestack/spokestack/android/SpeechRecognizerError.java
@@ -7,6 +7,11 @@ package io.spokestack.spokestack.android;
 public class SpeechRecognizerError extends Exception {
 
     /**
+     * The description of the Android system error code.
+     */
+    public final Description description;
+
+    /**
      * Create a new SpeechRecognizerError from an error code provided by the
      * Android system.
      *
@@ -15,13 +20,14 @@ public class SpeechRecognizerError extends Exception {
     public SpeechRecognizerError(int errorCode) {
         super("SpeechRecognizer error code " + errorCode + ": "
               + SpeechRecognizerError.errorDescription(errorCode));
+        this.description = SpeechRecognizerError.errorDescription(errorCode);
     }
 
-    private static String errorDescription(int errorCode) {
+    private static Description errorDescription(int errorCode) {
         if (errorCode < Description.VALUES.length) {
-            return Description.VALUES[errorCode].toString();
+            return Description.VALUES[errorCode];
         } else {
-            return Description.UNKNOWN_ERROR.toString();
+            return Description.UNKNOWN_ERROR;
         }
     }
 

--- a/src/main/java/io/spokestack/spokestack/profile/PushToTalkAndroidASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/PushToTalkAndroidASR.java
@@ -21,15 +21,7 @@ public class PushToTalkAndroidASR implements PipelineProfile {
     public SpeechPipeline.Builder apply(SpeechPipeline.Builder builder) {
         return builder
               .setInputClass(
-                    "io.spokestack.spokestack.android.MicrophoneInput")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AutomaticGainControl")
-              .setProperty("agc-compression-gain-db", 15)
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.VoiceActivityDetector")
-              .addStageClass("io.spokestack.spokestack.ActivationTimeout")
+                    "io.spokestack.spokestack.android.NoInput")
               .addStageClass(
                     "io.spokestack.spokestack.android.AndroidSpeechRecognizer");
     }

--- a/src/main/java/io/spokestack/spokestack/profile/TFWakewordAndroidASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/TFWakewordAndroidASR.java
@@ -49,7 +49,7 @@ public class TFWakewordAndroidASR implements PipelineProfile {
     public SpeechPipeline.Builder apply(SpeechPipeline.Builder builder) {
         return builder
               .setInputClass(
-                    "io.spokestack.spokestack.android.MicrophoneInput")
+                    "io.spokestack.spokestack.android.PreASRMicrophoneInput")
               .addStageClass(
                     "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
               .setProperty("ans-policy", "aggressive")
@@ -65,8 +65,6 @@ public class TFWakewordAndroidASR implements PipelineProfile {
                     "io.spokestack.spokestack.wakeword.WakewordTrigger")
               .setProperty("wake-threshold", 0.9)
               .setProperty("pre-emphasis", 0.97)
-              .addStageClass("io.spokestack.spokestack.ActivationTimeout")
-              .setProperty("active-min", 2000)
               .addStageClass(
                     "io.spokestack.spokestack.android.AndroidSpeechRecognizer");
     }

--- a/src/main/java/io/spokestack/spokestack/profile/VADTriggerAndroidASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/VADTriggerAndroidASR.java
@@ -21,7 +21,7 @@ public class VADTriggerAndroidASR implements PipelineProfile {
     public SpeechPipeline.Builder apply(SpeechPipeline.Builder builder) {
         return builder
               .setInputClass(
-                    "io.spokestack.spokestack.android.MicrophoneInput")
+                    "io.spokestack.spokestack.android.PreASRMicrophoneInput")
               .addStageClass(
                     "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
               .addStageClass(
@@ -31,7 +31,6 @@ public class VADTriggerAndroidASR implements PipelineProfile {
                     "io.spokestack.spokestack.webrtc.VoiceActivityDetector")
               .addStageClass(
                     "io.spokestack.spokestack.webrtc.VoiceActivityTrigger")
-              .addStageClass("io.spokestack.spokestack.ActivationTimeout")
               .addStageClass(
                     "io.spokestack.spokestack.android.AndroidSpeechRecognizer");
     }

--- a/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
+++ b/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
@@ -133,12 +133,12 @@ public class SpeechPipelineTest implements OnSpeechEventListener {
         });
 
         // first frame
-        transact();
+        transact(false);
         assertEquals(SpeechContext.Event.ACTIVATE, this.events.get(0));
         assertTrue(pipeline.getContext().isActive());
 
         // next frame
-        transact();
+        transact(false);
         assertEquals(SpeechContext.Event.DEACTIVATE, this.events.get(0));
         assertFalse(pipeline.getContext().isActive());
 
@@ -170,7 +170,7 @@ public class SpeechPipelineTest implements OnSpeechEventListener {
             .build();
         pipeline.start();
 
-        transact();
+        transact(false);
         assertEquals(SpeechContext.Event.ERROR, this.events.get(0));
         this.events.clear();
 
@@ -179,11 +179,46 @@ public class SpeechPipelineTest implements OnSpeechEventListener {
         assertEquals(SpeechContext.Event.ERROR, this.events.get(0));
     }
 
-    private void transact() throws Exception {
+    @Test
+    public void testContextManagement() throws Exception {
+        SpeechPipeline pipeline = new SpeechPipeline.Builder()
+              .setInputClass("io.spokestack.spokestack.SpeechPipelineTest$ManagedInput")
+              .addStageClass("io.spokestack.spokestack.SpeechPipelineTest$Stage")
+              .addOnSpeechEventListener(this)
+              .build();
+        pipeline.start();
+
+        // no activation event because stages don't run
+        pipeline.getContext().setManaged(true);
+        transact(true);
+        assertTrue(this.events.isEmpty());
+        assertFalse(pipeline.getContext().isActive());
+
+        // still no event, and the external activation isn't overridden by the
+        // stage, which would normally deactivate on the second frame
+        pipeline.getContext().setActive(true);
+        transact(true);
+        assertTrue(this.events.isEmpty());
+        assertTrue(pipeline.getContext().isActive());
+
+        // turn off external management and get the expected activations/events
+        pipeline.getContext().setManaged(false);
+        transact(false);
+        assertEquals(SpeechContext.Event.ACTIVATE, this.events.get(0));
+        assertTrue(pipeline.getContext().isActive());
+        transact(false);
+        assertEquals(SpeechContext.Event.DEACTIVATE, this.events.get(0));
+        assertFalse(pipeline.getContext().isActive());
+    }
+
+    private void transact(boolean managed) throws Exception {
         this.events.clear();
         Input.send();
-        while (this.events.isEmpty())
-            Thread.sleep(0);
+        if (!managed) {
+            while (this.events.isEmpty()) {
+                Thread.sleep(0);
+            }
+        }
     }
 
     public void onEvent(SpeechContext.Event event, SpeechContext context) {
@@ -205,7 +240,8 @@ public class SpeechPipelineTest implements OnSpeechEventListener {
             counter = -1;
         }
 
-        public void read(ByteBuffer frame) throws InterruptedException {
+        public void read(SpeechContext context, ByteBuffer frame)
+              throws InterruptedException {
             if (!stopped) {
                 semaphore.acquire();
                 frame.putInt(0, ++counter);
@@ -219,6 +255,19 @@ public class SpeechPipelineTest implements OnSpeechEventListener {
         public static void stop() {
             stopped = true;
             semaphore.release();
+        }
+    }
+
+    private static class ManagedInput extends Input {
+        public ManagedInput(SpeechConfig config) {
+            super(config);
+        }
+
+        @Override
+        public void read(SpeechContext context, ByteBuffer frame) throws InterruptedException {
+            if (!context.isManaged()) {
+                super.read(context, frame);
+            }
         }
     }
 
@@ -259,7 +308,8 @@ public class SpeechPipelineTest implements OnSpeechEventListener {
             throw new Exception("fail");
         }
 
-        public void read(ByteBuffer frame) throws Exception {
+        public void read(SpeechContext context, ByteBuffer frame)
+              throws Exception {
             throw new Exception("fail");
         }
     }

--- a/src/test/java/io/spokestack/spokestack/android/MicrophoneInputTest.java
+++ b/src/test/java/io/spokestack/spokestack/android/MicrophoneInputTest.java
@@ -1,6 +1,7 @@
-import java.util.*;
 import java.nio.ByteBuffer;
 
+import io.spokestack.spokestack.SpeechConfig;
+import io.spokestack.spokestack.SpeechContext;
 import org.junit.Test;
 import org.junit.jupiter.api.function.Executable;
 import static org.junit.jupiter.api.Assertions.*;
@@ -17,6 +18,7 @@ public class MicrophoneInputTest {
         final AudioRecord recorder = mock(AudioRecord.class);
         final MicrophoneInput input = new MicrophoneInput(recorder);
         final ByteBuffer buffer = ByteBuffer.allocateDirect(42);
+        final SpeechContext context = new SpeechContext(new SpeechConfig());
 
         verify(recorder).startRecording();
 
@@ -24,13 +26,13 @@ public class MicrophoneInputTest {
         when(recorder.read(any(ByteBuffer.class), anyInt()))
             .thenReturn(1);
         assertThrows(IllegalStateException.class, new Executable() {
-            public void execute() { input.read(buffer); }
+            public void execute() { input.read(context, buffer); }
         });
 
         // valid read
         when(recorder.read(any(ByteBuffer.class), anyInt()))
             .thenReturn(buffer.capacity());
-        input.read(buffer);
+        input.read(context, buffer);
 
         input.close();
         verify(recorder).release();

--- a/src/test/java/io/spokestack/spokestack/android/MockRecognizer.java
+++ b/src/test/java/io/spokestack/spokestack/android/MockRecognizer.java
@@ -57,18 +57,18 @@ public class MockRecognizer {
               .getFloatArray(SpeechRecognizer.CONFIDENCE_SCORES))
               .thenReturn(confidences);
 
+        recognitionListener.onReadyForSpeech(null);
+        recognitionListener.onRmsChanged(0);
+        recognitionListener.onBufferReceived(new byte[]{});
+        recognitionListener.onBeginningOfSpeech();
+        recognitionListener.onPartialResults(results);
+        recognitionListener.onEndOfSpeech();
+        recognitionListener.onEvent(0, null);
+
         if (this.isSuccessful) {
             recognitionListener.onResults(results);
         } else {
             recognitionListener.onError(4);
         }
-
-        recognitionListener.onReadyForSpeech(null);
-        recognitionListener.onBeginningOfSpeech();
-        recognitionListener.onRmsChanged(0);
-        recognitionListener.onBufferReceived(new byte[]{});
-        recognitionListener.onEndOfSpeech();
-        recognitionListener.onPartialResults(results);
-        recognitionListener.onEvent(0, null);
     }
 }

--- a/src/test/java/io/spokestack/spokestack/android/PreASRMicrophoneInputTest.java
+++ b/src/test/java/io/spokestack/spokestack/android/PreASRMicrophoneInputTest.java
@@ -1,0 +1,82 @@
+package io.spokestack.spokestack.android;
+
+import android.media.AudioRecord;
+import io.spokestack.spokestack.SpeechConfig;
+import io.spokestack.spokestack.SpeechContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.*;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({AudioRecord.class, PreASRMicrophoneInput.class})
+public class PreASRMicrophoneInputTest {
+
+    @Before
+    public void before() throws Exception{
+        mockStatic(AudioRecord.class);
+        AudioRecord record = mock(AudioRecord.class);
+        whenNew(AudioRecord.class).withAnyArguments().thenReturn(record);
+        // reads are valid by default
+        when(record.read(any(ByteBuffer.class), anyInt()))
+              .thenAnswer((invocation) -> {
+                  Object[] args = invocation.getArguments();
+                  return args[1];
+              });
+    }
+
+    @Test
+    public void testRead() {
+        final SpeechConfig config = new SpeechConfig();
+        config.put("sample-rate", 16000);
+        final PreASRMicrophoneInput input =
+              new PreASRMicrophoneInput(config);
+        final ByteBuffer buffer = ByteBuffer.allocateDirect(42);
+        final SpeechContext context = new SpeechContext(new SpeechConfig());
+
+        // establish the AudioRecord
+        input.read(context, buffer);
+        AudioRecord recorder = input.getRecorder();
+
+        // invalid read
+        when(recorder.read(any(ByteBuffer.class), anyInt())).thenReturn(1);
+        assertThrows(IllegalStateException.class, () ->
+              input.read(context, buffer));
+
+        verify(recorder).startRecording();
+
+        // valid read
+        when(recorder.read(any(ByteBuffer.class), anyInt()))
+              .thenReturn(buffer.capacity());
+        input.read(context, buffer);
+        assertNotNull(input.getRecorder());
+
+        // ASR active
+        context.setActive(true);
+        input.read(context, buffer);
+        verify(recorder).release();
+        assertNull(input.getRecorder());
+
+        // ASR inactive - new AudioRecord is created
+        context.setActive(false);
+        input.read(context, buffer);
+        recorder = input.getRecorder();
+        assertNotNull(recorder);
+
+        input.close();
+        verify(recorder, times(2)).release();
+    }
+
+}


### PR DESCRIPTION
This fixes an issue with the AndroidSpeechRecognizer class
that was resulting in no speech being sent to the ASR on
many devices.

It adds new input components capable of releasing the microphone
when ASR is active or avoiding capturing it altogether.

External management of the microphone is communicated via the speech
context; when Spokestack is not managing the microphone, pipeline
stages are not run.

Pipeline stages for the Android ASR profiles have been updated to use these new input classes and avoid unnecessary stages.

The AndroidSpeechRecognizer itself has been updated to manage the speech context where appropriate and to dispatch recognizer timeouts as timeout events instead of errors.

Since part of this changeset touches the foundations of the pipeline, I went ahead and tagged @brentspell as well.

One outstanding question: would it make sense to roll the context-awareness back into `MicrophoneInput` and avoid creating a new class, or does the separation help clarity?