### PR TITLE
Feature: Allow TTS playback to be stopped

### DIFF
--- a/src/main/java/io/spokestack/spokestack/SpeechOutput.java
+++ b/src/main/java/io/spokestack/spokestack/SpeechOutput.java
@@ -22,7 +22,9 @@ import io.spokestack.spokestack.tts.TTSListener;
  * thus, if a TTS subsystem has an output class, additional listeners are not
  * required. {@code SpeechOutput} components do publish their own events using
  * the same interface, however, so an app may wish to include a listener
- * component to receive media player events or errors.
+ * component to receive media player events or errors. A separate listener is
+ * also useful for re-opening the microphone (activating the speech pipeline)
+ * when playback is complete.
  * </p>
  *
  * <p>
@@ -50,6 +52,12 @@ public abstract class SpeechOutput extends TTSComponent
      *                 audio.
      */
     public abstract void audioReceived(AudioResponse response);
+
+    /**
+     * Stops playback of any currently playing and queued synthesis results and
+     * clears the play queue.
+     */
+    public abstract void stopPlayback();
 
     /**
      * Sets the output's Android context.

--- a/src/main/java/io/spokestack/spokestack/tts/TTSManager.java
+++ b/src/main/java/io/spokestack/spokestack/tts/TTSManager.java
@@ -110,6 +110,15 @@ public final class TTSManager implements AutoCloseable {
     }
 
     /**
+     * Stops playback of any playing or queued synthesis results.
+     */
+    public void stopPlayback() {
+        if (this.output != null) {
+            this.output.stopPlayback();
+        }
+    }
+
+    /**
      * Registers the currently active lifecycle with the manager, allowing any
      * output classes to handle media player components based on system
      * lifecycle events.

--- a/src/test/java/io/spokestack/spokestack/tts/TTSManagerTest.java
+++ b/src/test/java/io/spokestack/spokestack/tts/TTSManagerTest.java
@@ -108,6 +108,32 @@ public class TTSManagerTest implements TTSListener {
         assertEquals(errorMsg, lastEvent.getError().getMessage());
     }
 
+    @Test
+    public void testStop() throws Exception {
+        TTSManager manager = new TTSManager.Builder()
+              .setTTSServiceClass("io.spokestack.spokestack.tts.TTSManagerTest$Input")
+              .setProperty("spokestack-id", "test")
+              .setConfig(new SpeechConfig())
+              .setAndroidContext(context)
+              .addTTSListener(this)
+              .build();
+
+        // stopping playback with no registered output class does nothing
+        manager.stopPlayback();
+
+        manager = new TTSManager.Builder()
+              .setTTSServiceClass("io.spokestack.spokestack.tts.TTSManagerTest$Input")
+              .setOutputClass("io.spokestack.spokestack.tts.TTSManagerTest$Output")
+              .setProperty("spokestack-id", "test")
+              .setConfig(new SpeechConfig())
+              .setAndroidContext(context)
+              .addTTSListener(this)
+              .build();
+
+        manager.stopPlayback();
+        assertEquals("stop", events.remove(), "stop not called on output");
+    }
+
     @Override
     public void eventReceived(TTSEvent event) {
         lastEvent = event;
@@ -153,6 +179,11 @@ public class TTSManagerTest implements TTSListener {
         @Override
         public void audioReceived(AudioResponse response) {
             events.add("audioReceived");
+        }
+
+        @Override
+        public void stopPlayback() {
+            events.add("stop");
         }
 
         @Override


### PR DESCRIPTION
Does what it says on the tin. Currently, if you interrupt playback to, say, reactivate the Android ASR (with its signature beep), the TTS will go right on playing after the beep is over. This lets the user decide when TTS should be cut off for good.