### PR TITLE
fix concurrency issue in test

### DIFF
--- a/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
+++ b/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
@@ -206,6 +206,7 @@ public class SpeechPipelineTest implements OnSpeechEventListener {
         transact(false);
         assertEquals(SpeechContext.Event.ACTIVATE, this.events.get(0));
         assertTrue(pipeline.getContext().isActive());
+        this.events.clear();
         transact(false);
         assertEquals(SpeechContext.Event.DEACTIVATE, this.events.get(0));
         assertFalse(pipeline.getContext().isActive());


### PR DESCRIPTION
`Thread.sleep` considered temperamental.