### PR TITLE
Feature: add annotations to speech events

### DIFF
--- a/src/main/java/io/spokestack/spokestack/OnSpeechEventListener.java
+++ b/src/main/java/io/spokestack/spokestack/OnSpeechEventListener.java
@@ -1,18 +1,24 @@
 package io.spokestack.spokestack;
 
+import androidx.annotation.NonNull;
+
 /**
  * speech event callback interface.
  *
- * This is the primary event interface in Spokestack. The speech pipeline
- * routes events/errors asynchronously through it as they occur.
+ * <p>
+ * This is the primary event interface in Spokestack. The speech pipeline routes
+ * events/errors asynchronously through it as they occur.
+ * </p>
  */
 public interface OnSpeechEventListener {
     /**
      * receives a speech event.
+     *
      * @param event   the name of the event that was raised
      * @param context the current speech context
      * @throws Exception on error
      */
-    void onEvent(SpeechContext.Event event, SpeechContext context)
-        throws Exception;
+    void onEvent(@NonNull SpeechContext.Event event,
+                 @NonNull SpeechContext context)
+          throws Exception;
 }

--- a/src/test/java/io/spokestack/spokestack/ActivationTimeoutTest.java
+++ b/src/test/java/io/spokestack/spokestack/ActivationTimeoutTest.java
@@ -1,5 +1,6 @@
 package io.spokestack.spokestack;
 
+import androidx.annotation.NonNull;
 import io.spokestack.spokestack.tensorflow.TensorflowModel;
 import io.spokestack.spokestack.wakeword.WakewordTrigger;
 import io.spokestack.spokestack.wakeword.WakewordTriggerTest;
@@ -102,7 +103,7 @@ public class ActivationTimeoutTest {
             this.timeout.close();
         }
 
-        public void onEvent(SpeechContext.Event event, SpeechContext context) {
+        public void onEvent(@NonNull SpeechContext.Event event, @NonNull SpeechContext context) {
             this.event = event;
         }
     }

--- a/src/test/java/io/spokestack/spokestack/SpeechContextTest.java
+++ b/src/test/java/io/spokestack/spokestack/SpeechContextTest.java
@@ -3,6 +3,7 @@ package io.spokestack.spokestack;
 import java.util.*;
 import java.nio.ByteBuffer;
 
+import androidx.annotation.NonNull;
 import io.spokestack.spokestack.util.EventTracer;
 import org.junit.Test;
 import static org.junit.jupiter.api.Assertions.*;
@@ -123,7 +124,8 @@ public class SpeechContextTest implements OnSpeechEventListener {
         // listener error
         context.addOnSpeechEventListener(this);
         context.addOnSpeechEventListener(new OnSpeechEventListener() {
-            public void onEvent(Event event, SpeechContext context)
+            public void onEvent(@NonNull Event event,
+                                @NonNull SpeechContext context)
                     throws Exception{
                 throw new Exception("failed");
             }
@@ -213,7 +215,7 @@ public class SpeechContextTest implements OnSpeechEventListener {
         assertNull(this.event);
     }
 
-    public void onEvent(Event event, SpeechContext context) {
+    public void onEvent(@NonNull Event event, @NonNull SpeechContext context) {
         this.event = event;
         this.context = context;
     }

--- a/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
+++ b/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
@@ -5,6 +5,7 @@ import java.util.*;
 import java.util.concurrent.Semaphore;
 import java.nio.ByteBuffer;
 
+import androidx.annotation.NonNull;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -221,7 +222,8 @@ public class SpeechPipelineTest implements OnSpeechEventListener {
         }
     }
 
-    public void onEvent(SpeechContext.Event event, SpeechContext context) {
+    public void onEvent(@NonNull SpeechContext.Event event,
+                        @NonNull SpeechContext context) {
         this.events.add(event);
     }
 
@@ -264,7 +266,8 @@ public class SpeechPipelineTest implements OnSpeechEventListener {
         }
 
         @Override
-        public void read(SpeechContext context, ByteBuffer frame) throws InterruptedException {
+        public void read(SpeechContext context, ByteBuffer frame)
+              throws InterruptedException {
             if (!context.isManaged()) {
                 super.read(context, frame);
             }

--- a/src/test/java/io/spokestack/spokestack/android/AndroidSpeechRecognizerTest.java
+++ b/src/test/java/io/spokestack/spokestack/android/AndroidSpeechRecognizerTest.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.speech.RecognitionListener;
 import android.speech.SpeechRecognizer;
+import androidx.annotation.NonNull;
 import io.spokestack.spokestack.OnSpeechEventListener;
 import io.spokestack.spokestack.SpeechConfig;
 import io.spokestack.spokestack.SpeechContext;
@@ -191,7 +192,8 @@ public class AndroidSpeechRecognizerTest {
         }
 
         @Override
-        public void onEvent(SpeechContext.Event event, SpeechContext context) {
+        public void onEvent(@NonNull SpeechContext.Event event,
+                            @NonNull SpeechContext context) {
             switch (event) {
                 case RECOGNIZE:
                     this.transcript = context.getTranscript();

--- a/src/test/java/io/spokestack/spokestack/asr/SpokestackCloudRecognizerTest.java
+++ b/src/test/java/io/spokestack/spokestack/asr/SpokestackCloudRecognizerTest.java
@@ -1,5 +1,6 @@
 package io.spokestack.spokestack.asr;
 
+import androidx.annotation.NonNull;
 import io.spokestack.spokestack.OnSpeechEventListener;
 import io.spokestack.spokestack.SpeechConfig;
 import io.spokestack.spokestack.SpeechContext;
@@ -124,7 +125,8 @@ public class SpokestackCloudRecognizerTest implements OnSpeechEventListener {
         return context;
     }
 
-    public void onEvent(SpeechContext.Event event, SpeechContext context) {
+    public void onEvent(@NonNull SpeechContext.Event event,
+                        @NonNull SpeechContext context) {
         this.event = event;
     }
 }

--- a/src/test/java/io/spokestack/spokestack/google/GoogleSpeechRecognizerTest.java
+++ b/src/test/java/io/spokestack/spokestack/google/GoogleSpeechRecognizerTest.java
@@ -3,6 +3,7 @@ package io.spokestack.spokestack.google;
 import java.util.*;
 import java.nio.ByteBuffer;
 
+import androidx.annotation.NonNull;
 import org.junit.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -151,7 +152,8 @@ public class GoogleSpeechRecognizerTest implements OnSpeechEventListener {
         return context;
     }
 
-    public void onEvent(SpeechContext.Event event, SpeechContext context) {
+    public void onEvent(@NonNull SpeechContext.Event event,
+                        @NonNull SpeechContext context) {
         this.event = event;
     }
 

--- a/src/test/java/io/spokestack/spokestack/microsoft/AzureSpeechRecognizerTest.java
+++ b/src/test/java/io/spokestack/spokestack/microsoft/AzureSpeechRecognizerTest.java
@@ -1,5 +1,6 @@
 package io.spokestack.spokestack.microsoft;
 
+import androidx.annotation.NonNull;
 import com.microsoft.cognitiveservices.speech.CancellationErrorCode;
 import com.microsoft.cognitiveservices.speech.CancellationReason;
 import com.microsoft.cognitiveservices.speech.ResultReason;
@@ -187,7 +188,8 @@ public class AzureSpeechRecognizerTest implements OnSpeechEventListener {
         return context;
     }
 
-    public void onEvent(SpeechContext.Event event, SpeechContext context) {
+    public void onEvent(@NonNull SpeechContext.Event event,
+                        @NonNull SpeechContext context) {
         this.event = event;
     }
 }

--- a/src/test/java/io/spokestack/spokestack/wakeword/WakewordTriggerTest.java
+++ b/src/test/java/io/spokestack/spokestack/wakeword/WakewordTriggerTest.java
@@ -3,6 +3,7 @@ package io.spokestack.spokestack.wakeword;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import androidx.annotation.NonNull;
 import org.junit.Test;
 import org.junit.jupiter.api.function.Executable;
 import static org.junit.jupiter.api.Assertions.*;
@@ -293,7 +294,8 @@ public class WakewordTriggerTest {
             this.wake.process(this.context, this.frame);
         }
 
-        public void onEvent(SpeechContext.Event event, SpeechContext context) {
+        public void onEvent(@NonNull SpeechContext.Event event,
+                            @NonNull SpeechContext context) {
             this.event = event;
         }
     }

--- a/src/test/java/io/spokestack/spokestack/webrtc/VoiceActivityTriggerTest.java
+++ b/src/test/java/io/spokestack/spokestack/webrtc/VoiceActivityTriggerTest.java
@@ -1,5 +1,6 @@
 import java.nio.ByteBuffer;
 
+import androidx.annotation.NonNull;
 import org.junit.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -53,7 +54,8 @@ public class VoiceActivityTriggerTest implements OnSpeechEventListener {
         return ByteBuffer.allocateDirect(samples * 2);
     }
 
-    public void onEvent(SpeechContext.Event event, SpeechContext context) {
+    public void onEvent(@NonNull SpeechContext.Event event,
+                        @NonNull SpeechContext context) {
         this.event = event;
     }
 }


### PR DESCRIPTION
This is a followup to #75 that extends the annotations to the main speech event. The annotations make Kotlin client code cleaner because you're not forced to declare event parameters as optionals and subsequently unwrap them in your method bodies, but they also sadly indicate a major release because the compiler complains if you have method overrides that _do_ use optionals for params marked with these annotations.