### PR TITLE
Android ASR fix

### DIFF
--- a/src/main/java/io/spokestack/spokestack/android/AndroidSpeechRecognizer.java
+++ b/src/main/java/io/spokestack/spokestack/android/AndroidSpeechRecognizer.java
@@ -152,8 +152,6 @@ public class AndroidSpeechRecognizer implements SpeechProcessor {
                   RecognizerIntent.EXTRA_SPEECH_INPUT_MINIMUM_LENGTH_MILLIS,
                   this.minActive);
         }
-        // added in API level 23
-        intent.putExtra("android.speech.extra.PREFER_OFFLINE", true);
         return intent;
     }
 


### PR DESCRIPTION
Google seems to have broken offline ASR for calling applications. It's unclear whether this is a bug or intentional, but after removing the request for the offline model, recognition does seem to still work (for now).