### PR TITLE
Feature: Propagate partial ASR results to client

### DIFF
--- a/src/main/java/io/spokestack/spokestack/SpeechContext.java
+++ b/src/main/java/io/spokestack/spokestack/SpeechContext.java
@@ -25,6 +25,8 @@ public final class SpeechContext {
         ACTIVATE("activate"),
         /** speech recognition has become inactive. */
         DEACTIVATE("deactivate"),
+        /** a partial speech result was received. */
+        PARTIAL_RECOGNIZE("partial_recognize"),
         /** speech was recognized. */
         RECOGNIZE("recognize"),
         /** the activation timeout expired. */

--- a/src/main/java/io/spokestack/spokestack/asr/SpokestackCloudClient.java
+++ b/src/main/java/io/spokestack/spokestack/asr/SpokestackCloudClient.java
@@ -153,11 +153,11 @@ public class SpokestackCloudClient {
             if (response.error != null) {
                 String err = String.format("ASR error: %s", response.error);
                 this.listener.onError(new Exception(err));
-            } else if (response.status.equals("ok") && response.isFinal
+            } else if (response.status.equals("ok")
                   && response.hypotheses.length > 0) {
                 String speech = response.hypotheses[0].transcript;
                 float confidence = response.hypotheses[0].confidence;
-                this.listener.onSpeech(speech, confidence);
+                this.listener.onSpeech(speech, confidence, response.isFinal);
             }
         }
 
@@ -273,12 +273,11 @@ public class SpokestackCloudClient {
     public interface Listener {
         /**
          * called when a speech transcription is received.
-         *
-         * @param transcript the speech transcript, or "" if no speech was
-         *                   detected
+         *  @param transcript the speech transcript
          * @param confidence the recognizer's confidence in {@code transcript}
+         * @param isFinal    flag representing whether the result is final
          */
-        void onSpeech(String transcript, float confidence);
+        void onSpeech(String transcript, float confidence, boolean isFinal);
 
         /**
          * called when a speech detection error occurred.

--- a/src/main/java/io/spokestack/spokestack/asr/SpokestackCloudRecognizer.java
+++ b/src/main/java/io/spokestack/spokestack/asr/SpokestackCloudRecognizer.java
@@ -130,10 +130,15 @@ public final class SpokestackCloudRecognizer implements SpeechProcessor {
      * speech recognizer listener.
      */
     private class Listener implements SpokestackCloudClient.Listener {
-        public void onSpeech(String transcript, float confidence) {
+        public void onSpeech(String transcript,
+                             float confidence,
+                             boolean isFinal) {
             context.setTranscript(transcript);
             context.setConfidence(confidence);
-            context.dispatch(SpeechContext.Event.RECOGNIZE);
+            SpeechContext.Event event = (isFinal)
+                  ? SpeechContext.Event.RECOGNIZE
+                  : SpeechContext.Event.PARTIAL_RECOGNIZE;
+            context.dispatch(event);
         }
 
         public void onError(Throwable e) {

--- a/src/test/java/io/spokestack/spokestack/android/MockRecognizer.java
+++ b/src/test/java/io/spokestack/spokestack/android/MockRecognizer.java
@@ -61,7 +61,6 @@ public class MockRecognizer {
         recognitionListener.onRmsChanged(0);
         recognitionListener.onBufferReceived(new byte[]{});
         recognitionListener.onBeginningOfSpeech();
-        recognitionListener.onPartialResults(results);
         recognitionListener.onEndOfSpeech();
         recognitionListener.onEvent(0, null);
 
@@ -70,5 +69,27 @@ public class MockRecognizer {
         } else {
             recognitionListener.onError(4);
         }
+    }
+
+    public static Bundle speechResults(String transcript) {
+        return MockRecognizer.speechResults(transcript, null);
+    }
+
+    public static Bundle speechResults(String transcript, Float confidence) {
+        Bundle results = mock(Bundle.class);
+        ArrayList<String> nBest =
+              new ArrayList<>( Arrays.asList(TRANSCRIPT, transcript));
+        when(results
+              .getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION))
+              .thenReturn(nBest);
+        float[] confidences = null;
+        if (confidence != null) {
+            confidences = new float[]{confidence};
+        }
+
+        when(results
+              .getFloatArray(SpeechRecognizer.CONFIDENCE_SCORES))
+              .thenReturn(confidences);
+        return results;
     }
 }

--- a/src/test/java/io/spokestack/spokestack/asr/SpokestackCloudRecognizerTest.java
+++ b/src/test/java/io/spokestack/spokestack/asr/SpokestackCloudRecognizerTest.java
@@ -63,8 +63,13 @@ public class SpokestackCloudRecognizerTest implements OnSpeechEventListener {
 
 
         // responses
-        listener.onSpeech("test", 0.9f);
-        assertEquals("test", context.getTranscript());
+        listener.onSpeech("test one", 0.9f, false);
+        assertEquals("test one", context.getTranscript());
+        assertEquals(0.9f, context.getConfidence(), 1e-5);
+        assertEquals(SpeechContext.Event.PARTIAL_RECOGNIZE, this.event);
+
+        listener.onSpeech("test two", 0.9f, true);
+        assertEquals("test two", context.getTranscript());
         assertEquals(0.9f, context.getConfidence(), 1e-5);
         assertEquals(SpeechContext.Event.RECOGNIZE, this.event);
 


### PR DESCRIPTION
This feature passes partial speech recognition results available
from all current ASR providers along to the client for optional
display. It does this by populating the speech context's
transcript with the partial result and firing a new
PARTIAL_RECOGNITION event.

Nothing has changed about the final transcript; it is available
from the speech context when a RECOGNIZE event is fired.