### PR TITLE
Feature: Allow `start` call on a running pipeline

### DIFF
--- a/src/main/java/io/spokestack/spokestack/SpeechPipeline.java
+++ b/src/main/java/io/spokestack/spokestack/SpeechPipeline.java
@@ -139,7 +139,9 @@ public final class SpeechPipeline implements AutoCloseable {
      */
     public void start() throws Exception {
         if (this.running) {
-            throw new IllegalStateException("already running");
+            this.context.traceInfo(
+                  "attempting to start a running pipeline; ignoring");
+            return;
         }
 
         try {

--- a/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
+++ b/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
@@ -6,6 +6,7 @@ import java.util.concurrent.Semaphore;
 import java.nio.ByteBuffer;
 
 import androidx.annotation.NonNull;
+import io.spokestack.spokestack.util.EventTracer;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -118,6 +119,7 @@ public class SpeechPipelineTest implements OnSpeechEventListener {
             .setProperty("sample-rate", 16000)
             .setProperty("frame-width", 20)
             .setProperty("buffer-width", 300)
+            .setProperty("trace-level", EventTracer.Level.INFO.value())
             .addOnSpeechEventListener(this)
             .build();
 
@@ -128,10 +130,9 @@ public class SpeechPipelineTest implements OnSpeechEventListener {
         assertEquals(0, Input.counter);
         assertTrue(Stage.open);
 
-        // invalid restart
-        assertThrows(IllegalStateException.class, new Executable() {
-            public void execute() throws Exception { pipeline.start(); }
-        });
+        // idempotent restart
+        pipeline.start();
+        assertEquals(SpeechContext.Event.TRACE, this.events.get(0));
 
         // first frame
         transact(false);


### PR DESCRIPTION
This changes the semantics of `SpeechPipeline.start()` to make it
roughly idempotent: If a pipeline is running, `start` will emit an
info trace event, but no error will be thrown.