### PR TITLE
Feature: Expose Spokestack NLU slot types

### DIFF
--- a/src/main/java/io/spokestack/spokestack/nlu/Slot.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/Slot.java
@@ -6,25 +6,40 @@ import java.util.Objects;
  * A slot extracted during intent classification.
  *
  * <p>
- * Depending on the NLU service used, slots may be typed; if present, the type
- * of each slot can be accessed by calling {@code getClass()} on the slot's
- * value.
+ * Some NLU services allow user-specified types. If present, the
+ * user-specified type can be accessed via the {@code type} field, and the
+ * runtime type can be accessed by calling {@code getClass()} on the slot's
+ * {@code value}.
  * </p>
  */
 public final class Slot {
     private final String name;
+    private final String type;
     private final String rawValue;
     private final Object value;
 
     /**
      * Create a new slot.
      *
-     * @param n   The slot's name.
+     * @param n        The slot's name.
      * @param original The slot's original string value.
-     * @param parsed The slot's parsed value.
+     * @param parsed   The slot's parsed value.
      */
     public Slot(String n, String original, Object parsed) {
+        this(n, null, original, parsed);
+    }
+
+    /**
+     * Create a new slot with a user-specified type.
+     *
+     * @param n        The slot's name.
+     * @param userType The slot's type.
+     * @param original The slot's original string value.
+     * @param parsed   The slot's parsed value.
+     */
+    public Slot(String n, String userType, String original, Object parsed) {
         this.name = n;
+        this.type = userType;
         this.rawValue = original;
         this.value = parsed;
     }
@@ -34,6 +49,13 @@ public final class Slot {
      */
     public String getName() {
         return name;
+    }
+
+    /**
+     * @return The slot's type.
+     */
+    public String getType() {
+        return type;
     }
 
     /**
@@ -61,6 +83,7 @@ public final class Slot {
         }
         Slot slot = (Slot) o;
         return getName().equals(slot.getName())
+              && nullOrEqual(getType(), slot.getType())
               && nullOrEqual(getRawValue(), slot.getRawValue())
               && nullOrEqual(getValue(), slot.getValue());
     }
@@ -72,14 +95,15 @@ public final class Slot {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getName(), getValue());
+        return Objects.hash(getName(), getType(), getValue());
     }
 
     @Override
     public String toString() {
         return "Slot{"
               + "name=\"" + name
-              + "\", rawValue=" + rawValue
+              + "\", type=" + type
+              + ", rawValue=" + rawValue
               + ", value=" + value
               + '}';
     }

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TFNLUOutput.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TFNLUOutput.java
@@ -158,7 +158,8 @@ final class TFNLUOutput {
             if (slotVal == null) {
                 String captureName = metaSlot.getCaptureName();
                 if (!parsed.containsKey(captureName)) {
-                    Slot emptySlot = new Slot(captureName, slotVal, null);
+                    Slot emptySlot = new Slot(
+                          captureName, metaSlot.getType(), null, null);
                     parsed.put(captureName, emptySlot);
                 }
                 // else leave the existing (implicit) slot alone
@@ -174,7 +175,7 @@ final class TFNLUOutput {
         Map<String, Slot> slots = new HashMap<>();
         for (Metadata.Slot slot : intent.getImplicitSlots()) {
             String name = slot.getCaptureName();
-            Slot parsed = new Slot(name,
+            Slot parsed = new Slot(name, slot.getType(),
                   String.valueOf(slot.getValue()), slot.getValue());
             slots.put(name, parsed);
         }
@@ -186,7 +187,7 @@ final class TFNLUOutput {
         String slotName = metaSlot.getCaptureName();
         try {
             Object parsed = parser.parse(metaSlot.getFacets(), slotValue);
-            return new Slot(slotName, slotValue, parsed);
+            return new Slot(slotName, metaSlot.getType(), slotValue, parsed);
         } catch (Exception e) {
             throw new IllegalArgumentException("Error parsing slot "
                   + slotName, e);

--- a/src/test/java/io/spokestack/spokestack/nlu/tensorflow/TFNLUOutputTest.java
+++ b/src/test/java/io/spokestack/spokestack/nlu/tensorflow/TFNLUOutputTest.java
@@ -155,11 +155,12 @@ public class TFNLUOutputTest {
         slotValues.put("feature_2", "9");
 
         expected = new HashMap<>();
-        Slot implicitSlot = new Slot("feature_1", "default", "default");
+        Slot implicitSlot =
+              new Slot("feature_1", "entity", "default", "default");
         // no value is present in the output, so the implicit value is used
         expected.put("feature_1", implicitSlot);
         // note the name override
-        Slot captureNameSlot = new Slot("test_num", "9", 9);
+        Slot captureNameSlot = new Slot("test_num", "integer", "9", 9);
         expected.put("test_num", captureNameSlot);
 
         result = outputParser.parseSlots(intent, slotValues);
@@ -170,11 +171,12 @@ public class TFNLUOutputTest {
         slotValues.put("feature_1", "overridden");
 
         expected = new HashMap<>();
-        implicitSlot = new Slot("feature_1", "overridden", "overridden");
+        implicitSlot =
+              new Slot("feature_1", "entity", "overridden", "overridden");
         expected.put("feature_1", implicitSlot);
 
         // not present in slot tagger output, but included in client output
-        expected.put("test_num", new Slot("test_num", null, null));
+        expected.put("test_num", new Slot("test_num", "integer", null, null));
 
         result = outputParser.parseSlots(intent, slotValues);
         assertEquals(expected, result);

--- a/src/test/java/io/spokestack/spokestack/nlu/tensorflow/TensorflowNLUTest.java
+++ b/src/test/java/io/spokestack/spokestack/nlu/tensorflow/TensorflowNLUTest.java
@@ -108,8 +108,8 @@ public class TensorflowNLUTest {
 
         Map<String, Slot> slots = new HashMap<>();
         slots.put("noun_phrase",
-              new Slot("noun_phrase", "this code", "this code"));
-        slots.put("test_num", new Slot("test_num", "1", 1));
+              new Slot("noun_phrase", "entity", "this code", "this code"));
+        slots.put("test_num", new Slot("test_num", "integer", "1", 1));
 
         assertNull(result.getError());
         assertEquals("describe_test", result.getIntent());
@@ -137,8 +137,8 @@ public class TensorflowNLUTest {
 
         slots = new HashMap<>();
         slots.put("noun_phrase",
-              new Slot("noun_phrase", "this code", "this code"));
-        slots.put("test_num", new Slot("test_num", "1", 1));
+              new Slot("noun_phrase", "entity", "this code", "this code"));
+        slots.put("test_num", new Slot("test_num", "integer", "1", 1));
 
         assertNull(result.getError());
         assertEquals("describe_test", result.getIntent());


### PR DESCRIPTION
This change propagates slot types from the Spokestack NLU
metadata to the public Slot API, making them available for
use by other libraries, such as react-native-spokestack,
that wrap this native library.