### PR TITLE
Fix: re-authorize Spokestack ASR socket

### DIFF
--- a/src/main/java/io/spokestack/spokestack/asr/SpokestackCloudClient.java
+++ b/src/main/java/io/spokestack/spokestack/asr/SpokestackCloudClient.java
@@ -83,6 +83,16 @@ public class SpokestackCloudClient {
 
         Request request = new Request.Builder().url(SOCKET_URL).build();
         this.socket = this.client.newWebSocket(request, new SocketListener());
+    }
+
+    /**
+     * sends an initial empty request message to authenticate with the server.
+     */
+    public void init() {
+        if (this.socket == null) {
+            throw new IllegalStateException("disconnected_init");
+        }
+
         this.socket.send(this.authMessage);
     }
 

--- a/src/main/java/io/spokestack/spokestack/asr/SpokestackCloudRecognizer.java
+++ b/src/main/java/io/spokestack/spokestack/asr/SpokestackCloudRecognizer.java
@@ -108,6 +108,7 @@ public final class SpokestackCloudRecognizer implements SpeechProcessor {
         if (!this.client.isConnected()) {
             this.client.connect();
         }
+        this.client.init();
         this.active = true;
         this.idleCount = 0;
 

--- a/src/test/java/io/spokestack/spokestack/asr/SpokestackCloudClientTest.java
+++ b/src/test/java/io/spokestack/spokestack/asr/SpokestackCloudClientTest.java
@@ -10,6 +10,7 @@ import org.mockito.ArgumentCaptor;
 import java.nio.ByteBuffer;
 
 import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
@@ -105,12 +106,15 @@ public class SpokestackCloudClientTest
         // default connection
         assertFalse(client.isConnected());
 
+        // init before connect
+        assertThrows(IllegalStateException.class, client::init);
+
         // valid connection
         client.connect();
         assertTrue(client.isConnected());
 
-        // TODO failed auth
-        // successful auth
+        // no errors on init after connection
+        assertDoesNotThrow(client::init);
 
         // failed reconnection
         assertThrows(IllegalStateException.class, client::connect);
@@ -118,6 +122,9 @@ public class SpokestackCloudClientTest
         // valid disconnection
         client.disconnect();
         assertFalse(client.isConnected());
+
+        // init after disconnect
+        assertThrows(IllegalStateException.class, client::init);
 
         // safe redisconnection
         client.disconnect();

--- a/src/test/java/io/spokestack/spokestack/asr/SpokestackCloudRecognizerTest.java
+++ b/src/test/java/io/spokestack/spokestack/asr/SpokestackCloudRecognizerTest.java
@@ -4,65 +4,104 @@ import androidx.annotation.NonNull;
 import io.spokestack.spokestack.OnSpeechEventListener;
 import io.spokestack.spokestack.SpeechConfig;
 import io.spokestack.spokestack.SpeechContext;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.nio.ByteBuffer;
 import java.util.LinkedList;
+import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 public class SpokestackCloudRecognizerTest implements OnSpeechEventListener {
     private SpeechContext.Event event;
+    private SpeechConfig config;
+    private SpokestackCloudClient client;
+    private SpokestackCloudRecognizer recognizer;
+    private SpokestackCloudClient.Listener listener;
 
-    @Test
-    public void testRecognize() {
+    @Before
+    public void before() {
         SpokestackCloudClient.Builder builder =
               spy(SpokestackCloudClient.Builder.class);
-        SpokestackCloudClient client = mock(SpokestackCloudClient.class);
+        client = mock(SpokestackCloudClient.class);
         doReturn(client).when(builder).build();
 
-        SpeechConfig config = createConfig();
-        SpeechContext context = createContext(config);
-        SpokestackCloudRecognizer recognizer =
-              new SpokestackCloudRecognizer(config, builder);
+        config = createConfig();
+        recognizer = new SpokestackCloudRecognizer(config, builder);
 
         // capture the listener
         ArgumentCaptor<SpokestackCloudClient.Listener> captor =
               ArgumentCaptor.forClass(SpokestackCloudClient.Listener.class);
         verify(builder).setListener(captor.capture());
-        SpokestackCloudClient.Listener listener = captor.getValue();
+        listener = captor.getValue();
+    }
+
+    @Test
+    public void testRecognize() {
+        SpeechContext context = createContext(config);
 
         // inactive
         recognizer.process(context, context.getBuffer().getLast());
         verify(client, never()).connect();
 
-        // active/buffered frames
-        context.setActive(true);
-        recognizer.process(context, context.getBuffer().getLast());
-        verify(client).connect();
-        verify(client, times(context.getBuffer().size()))
+        // fake a socket connection to verify proper interactions
+        AtomicBoolean connected = new AtomicBoolean(false);
+        doAnswer(invocation -> {
+            connected.set(true);
+            return null;
+        }).when(client).connect();
+        doAnswer(invocation -> connected.get())
+              .when(client).isConnected();
+
+        // two utterances
+        sendUtterance(context);
+        sendUtterance(context);
+
+        // connect called once, init called for each utterance,
+        // end called for each utterance
+        verify(client, times(1)).connect();
+        verify(client, times(2)).init();
+        verify(client, times(2)).endAudio();
+
+        // each utterance processes the entire context buffer and one
+        // additional frame
+        int framesSent = (context.getBuffer().size() + 1) * 2;
+        verify(client, times(framesSent))
               .sendAudio(context.getBuffer().getLast());
-
-        // subsequent frame
-        reset(client);
-        recognizer.process(context, context.getBuffer().getLast());
-        verify(client).sendAudio(context.getBuffer().getLast());
-
-        // complete
-        context.setActive(false);
-        recognizer.process(context, context.getBuffer().getLast());
-        verify(client).endAudio();
 
         // idle timeout
         for (int i = 0; i < 500; i++) {
             recognizer.process(context, context.getBuffer().getLast());
         }
-        verify(client, atLeast(1)).disconnect();
+        verify(client, atLeastOnce()).disconnect();
 
+        // shutdown
+        recognizer.close();
+        verify(client).close();
+    }
 
-        // responses
+    private void sendUtterance(SpeechContext context) {
+        // active/buffered frames
+        context.setActive(true);
+        recognizer.process(context, context.getBuffer().getLast());
+
+        // subsequent frame
+        recognizer.process(context, context.getBuffer().getLast());
+
+        // complete
+        context.setActive(false);
+        recognizer.process(context, context.getBuffer().getLast());
+    }
+
+    @Test
+    public void testResponses() {
+        // process a frame to set the recognizer's context
+        SpeechContext context = createContext(config);
+        recognizer.process(context, context.getBuffer().getLast());
+
         listener.onSpeech("test one", 0.9f, false);
         assertEquals("test one", context.getTranscript());
         assertEquals(0.9f, context.getConfidence(), 1e-5);
@@ -72,10 +111,6 @@ public class SpokestackCloudRecognizerTest implements OnSpeechEventListener {
         assertEquals("test two", context.getTranscript());
         assertEquals(0.9f, context.getConfidence(), 1e-5);
         assertEquals(SpeechContext.Event.RECOGNIZE, this.event);
-
-        // shutdown
-        recognizer.close();
-        verify(client).close();
     }
 
     @Test


### PR DESCRIPTION
This fixes the usage of Spokestack ASR to comport with server
expectations. Previously, when a websocket was reused for a series
of utterances, an authorization request was only sent on initial
socket connection. It is now sent at the beginning of every utterance.