### PR TITLE
Fix: workaround for Android ASR timeouts

### DIFF
--- a/src/main/java/io/spokestack/spokestack/android/AndroidSpeechRecognizer.java
+++ b/src/main/java/io/spokestack/spokestack/android/AndroidSpeechRecognizer.java
@@ -175,8 +175,8 @@ public class AndroidSpeechRecognizer implements SpeechProcessor {
         @Override
         public void onError(int error) {
             SpeechRecognizerError speechErr = new SpeechRecognizerError(error);
-            if (speechErr.description
-                  == SpeechRecognizerError.Description.SPEECH_TIMEOUT) {
+            this.context.traceDebug("AndroidSpeechRecognizer error " + error);
+            if (isTimeout(speechErr.description)) {
                 this.context.dispatch(SpeechContext.Event.TIMEOUT);
             } else {
                 this.context.setError(speechErr);
@@ -184,6 +184,17 @@ public class AndroidSpeechRecognizer implements SpeechProcessor {
             }
             this.context.setSpeech(false);
             this.context.setActive(false);
+        }
+
+        private boolean isTimeout(
+              SpeechRecognizerError.Description description) {
+            // the NO_RECOGNITION_MATCH condition appears to be a bug on
+            // Google's part that cropped up since this class was written,
+            // but we'll leave the workaround in place unless/until they fix it
+            return description
+                  == SpeechRecognizerError.Description.SPEECH_TIMEOUT
+                  || description
+                  == SpeechRecognizerError.Description.NO_RECOGNITION_MATCH;
         }
 
         @Override

--- a/src/test/java/io/spokestack/spokestack/android/AndroidSpeechRecognizerTest.java
+++ b/src/test/java/io/spokestack/spokestack/android/AndroidSpeechRecognizerTest.java
@@ -181,6 +181,15 @@ public class AndroidSpeechRecognizerTest {
         assertEquals(eventListener.traces.get(numTraces - 1),
               EventListener.TIMEOUT);
 
+        // recognition match -> timeout (presumed Google bug)
+        eventListener.clear();
+        asrListener.onError(
+              SpeechRecognizerError.Description.NO_RECOGNITION_MATCH.ordinal());
+        assertNull(eventListener.error);
+        numTraces = eventListener.traces.size();
+        assertEquals(eventListener.traces.get(numTraces - 1),
+              EventListener.TIMEOUT);
+
         context.setActive(true);
         context.setSpeech(true);
 


### PR DESCRIPTION
This is a (hopefully temporary) workaround for a change we've
noticed in the Android ASR behavior. It's started sending
NO_MATCH errors for stretches of inactivity that used to result
in SPEECH_TIMEOUT errors. The former is treated as an actual error
in our library code, but the latter is a plain event, so having
them mismatched causes problems for clients. As a result we're
remapping NO_MATCH errors to timeouts.