### PR TITLE
fix: manage speech context better for Android ASR

### DIFF
--- a/src/main/java/io/spokestack/spokestack/android/AndroidSpeechRecognizer.java
+++ b/src/main/java/io/spokestack/spokestack/android/AndroidSpeechRecognizer.java
@@ -118,6 +118,7 @@ public class AndroidSpeechRecognizer implements SpeechProcessor {
 
         if (context.isActive()) {
             if (!this.streaming) {
+                context.setManaged(true);
                 begin();
                 this.streaming = true;
             }
@@ -182,8 +183,7 @@ public class AndroidSpeechRecognizer implements SpeechProcessor {
                 this.context.setError(speechErr);
                 this.context.dispatch(SpeechContext.Event.ERROR);
             }
-            this.context.setSpeech(false);
-            this.context.setActive(false);
+            relinquishContext();
         }
 
         private boolean isTimeout(
@@ -205,6 +205,7 @@ public class AndroidSpeechRecognizer implements SpeechProcessor {
         @Override
         public void onResults(Bundle results) {
             dispatchRecognition(results, false);
+            relinquishContext();
         }
 
         private void dispatchRecognition(Bundle results, boolean isPartial) {
@@ -233,6 +234,12 @@ public class AndroidSpeechRecognizer implements SpeechProcessor {
             return confidences[0];
         }
 
+        private void relinquishContext() {
+            this.context.setSpeech(false);
+            this.context.setActive(false);
+            this.context.setManaged(false);
+        }
+
         @Override
         public void onReadyForSpeech(Bundle params) {
             this.context.traceDebug(
@@ -241,7 +248,6 @@ public class AndroidSpeechRecognizer implements SpeechProcessor {
 
         @Override
         public void onBeginningOfSpeech() {
-            this.context.setActive(true);
             this.context.setSpeech(true);
             this.context.traceDebug("AndroidSpeechRecognizer begin speech");
         }
@@ -260,7 +266,6 @@ public class AndroidSpeechRecognizer implements SpeechProcessor {
         public void onEndOfSpeech() {
             this.context.traceDebug("AndroidSpeechRecognizer end speech");
             this.context.setSpeech(false);
-            this.context.setActive(false);
         }
 
         @Override

--- a/src/main/java/io/spokestack/spokestack/android/PreASRMicrophoneInput.java
+++ b/src/main/java/io/spokestack/spokestack/android/PreASRMicrophoneInput.java
@@ -84,7 +84,6 @@ public final class PreASRMicrophoneInput implements SpeechInput {
         if (this.recorder != null) {
             this.recorder.release();
             this.recorder = null;
-            context.setManaged(true);
         }
         this.recording = false;
     }
@@ -97,7 +96,6 @@ public final class PreASRMicrophoneInput implements SpeechInput {
               AudioFormat.ENCODING_PCM_16BIT,
               this.bufferSize
         );
-        context.setManaged(false);
         this.recorder.startRecording();
         this.recording = true;
     }

--- a/src/test/java/io/spokestack/spokestack/android/AndroidSpeechRecognizerTest.java
+++ b/src/test/java/io/spokestack/spokestack/android/AndroidSpeechRecognizerTest.java
@@ -160,16 +160,13 @@ public class AndroidSpeechRecognizerTest {
         assertFalse(context.isSpeech());
 
         asrListener.onBeginningOfSpeech();
-        assertTrue(context.isActive());
         assertTrue(context.isSpeech());
 
         asrListener.onEndOfSpeech();
-        assertFalse(context.isActive());
         assertFalse(context.isSpeech());
 
         // restart speech, then throw some errors
         asrListener.onBeginningOfSpeech();
-        assertTrue(context.isActive());
         assertTrue(context.isSpeech());
 
         asrListener.onError(


### PR DESCRIPTION
The Android speech recognizer does not always send events in
the order we originally expected, so the former speech context
management was a bit too aggressive. The Android ASR no longer
deactivates the speech context from within its internal
RecognitionListener until it's sure the interaction is over (via
a final reognition event or an error), and it now handles altering
the context's managed flag instead of leaving that to the microphone
input handler.