### PR TITLE
Fix: reset pipeline stages when context unmanaged

### DIFF
--- a/src/main/java/io/spokestack/spokestack/ActivationTimeout.java
+++ b/src/main/java/io/spokestack/spokestack/ActivationTimeout.java
@@ -71,14 +71,12 @@ public final class ActivationTimeout implements SpeechProcessor {
     }
 
     @Override
-    public void close() {
-        reset();
+    public void reset() {
+        close();
     }
 
-    /**
-     * Reset the trigger's activity timer.
-     */
-    public void reset() {
+    @Override
+    public void close() {
         this.activeLength = 0;
     }
 }

--- a/src/main/java/io/spokestack/spokestack/SpeechProcessor.java
+++ b/src/main/java/io/spokestack/spokestack/SpeechProcessor.java
@@ -24,4 +24,10 @@ public interface SpeechProcessor extends AutoCloseable {
      * @throws Exception on error
      */
     void process(SpeechContext context, ByteBuffer frame) throws Exception;
+
+    /**
+     * resets all state internal to the stage.
+     * @throws Exception on error
+     */
+    void reset() throws Exception;
 }

--- a/src/main/java/io/spokestack/spokestack/SpeechSampler.java
+++ b/src/main/java/io/spokestack/spokestack/SpeechSampler.java
@@ -77,6 +77,11 @@ public final class SpeechSampler implements SpeechProcessor {
         this.header.putInt(Integer.MAX_VALUE);      // size of data chunk
     }
 
+    @Override
+    public void reset() throws Exception {
+        close();
+    }
+
     /**
      * destroys the resources attached to the copmonent.
      * @throws Exception on error

--- a/src/main/java/io/spokestack/spokestack/android/AndroidSpeechRecognizer.java
+++ b/src/main/java/io/spokestack/spokestack/android/AndroidSpeechRecognizer.java
@@ -158,8 +158,16 @@ public class AndroidSpeechRecognizer implements SpeechProcessor {
     }
 
     @Override
+    public void reset() {
+       close();
+    }
+
+    @Override
     public void close() {
-        this.taskHandler.run(() -> this.speechRecognizer.destroy());
+        this.taskHandler.run(() -> {
+            this.speechRecognizer.destroy();
+            this.speechRecognizer = null;
+        });
     }
 
     /**

--- a/src/main/java/io/spokestack/spokestack/asr/SpokestackCloudRecognizer.java
+++ b/src/main/java/io/spokestack/spokestack/asr/SpokestackCloudRecognizer.java
@@ -78,9 +78,19 @@ public final class SpokestackCloudRecognizer implements SpeechProcessor {
               .build();
     }
 
+    @Override
+    public void reset() {
+        if (this.client.isConnected()) {
+            this.client.disconnect();
+        }
+        this.idleCount = 0;
+        this.active = false;
+    }
+
     /**
      * releases the resources associated with the recognizer.
      */
+    @Override
     public void close() {
         this.client.close();
     }

--- a/src/main/java/io/spokestack/spokestack/google/GoogleSpeechRecognizer.java
+++ b/src/main/java/io/spokestack/spokestack/google/GoogleSpeechRecognizer.java
@@ -103,13 +103,21 @@ public final class GoogleSpeechRecognizer implements SpeechProcessor {
             .build();
     }
 
+    @Override
+    public void reset() {
+        if (this.request != null) {
+            this.request.onCompleted();
+        }
+    }
+
     /**
      * releases the resources associated with the recognizer.
-     * @throws Exception on error
      */
-    public void close() throws Exception {
-        if (this.request != null)
+    @Override
+    public void close() {
+        if (this.request != null) {
             this.request.onCompleted();
+        }
         this.client.close();
     }
 

--- a/src/main/java/io/spokestack/spokestack/microsoft/AzureSpeechRecognizer.java
+++ b/src/main/java/io/spokestack/spokestack/microsoft/AzureSpeechRecognizer.java
@@ -106,9 +106,15 @@ public class AzureSpeechRecognizer implements SpeechProcessor {
         return config;
     }
 
+    @Override
+    public void reset() {
+        close();
+    }
+
     /**
      * releases the resources associated with the recognizer.
      */
+    @Override
     public void close() {
         if (this.audioStream != null) {
             this.audioStream.close();

--- a/src/main/java/io/spokestack/spokestack/webrtc/AcousticNoiseSuppressor.java
+++ b/src/main/java/io/spokestack/spokestack/webrtc/AcousticNoiseSuppressor.java
@@ -95,9 +95,14 @@ public class AcousticNoiseSuppressor implements SpeechProcessor {
             throw new OutOfMemoryError();
     }
 
+    @Override
+    public void reset() {
+    }
+
     /**
      * destroys the unmanaged ans instance.
      */
+    @Override
     public void close() {
         destroy(this.ansHandle);
     }

--- a/src/main/java/io/spokestack/spokestack/webrtc/AutomaticGainControl.java
+++ b/src/main/java/io/spokestack/spokestack/webrtc/AutomaticGainControl.java
@@ -101,6 +101,10 @@ public class AutomaticGainControl implements SpeechProcessor {
         destroy(this.agcHandle);
     }
 
+    @Override
+    public void reset() {
+    }
+
     /**
      * processes a frame of audio.
      * @param context the current speech context

--- a/src/main/java/io/spokestack/spokestack/webrtc/VoiceActivityDetector.java
+++ b/src/main/java/io/spokestack/spokestack/webrtc/VoiceActivityDetector.java
@@ -166,6 +166,12 @@ public class VoiceActivityDetector implements SpeechProcessor {
         }
     }
 
+    @Override
+    public void reset() {
+        this.runValue = false;
+        this.runLength = 0;
+    }
+
     //-----------------------------------------------------------------------
     // native interface
     //-----------------------------------------------------------------------

--- a/src/main/java/io/spokestack/spokestack/webrtc/VoiceActivityTrigger.java
+++ b/src/main/java/io/spokestack/spokestack/webrtc/VoiceActivityTrigger.java
@@ -46,4 +46,9 @@ public class VoiceActivityTrigger implements SpeechProcessor {
             this.isSpeech = context.isSpeech();
         }
     }
+
+    @Override
+    public void reset() {
+        this.isSpeech = false;
+    }
 }

--- a/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
+++ b/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
@@ -282,6 +282,10 @@ public class SpeechPipelineTest implements OnSpeechEventListener {
             open = true;
         }
 
+        public void reset() {
+            close();
+        }
+
         public void close() {
             open = false;
         }
@@ -322,6 +326,10 @@ public class SpeechPipelineTest implements OnSpeechEventListener {
         public FailStage(SpeechConfig config) {
         }
 
+        public void reset() throws Exception {
+            close();
+        }
+
         public void close() throws Exception {
             throw new Exception("fail");
         }
@@ -335,6 +343,10 @@ public class SpeechPipelineTest implements OnSpeechEventListener {
     public static class ConfigRequiredStage implements SpeechProcessor {
         public ConfigRequiredStage(SpeechConfig config) {
             config.getString("required-property");
+        }
+
+        public void reset() throws Exception {
+            close();
         }
 
         public void close() throws Exception {


### PR DESCRIPTION
This addresses an issue where internal speech processor state
was available, but stale, after the speech context left the "externally
managed" state, sometimes leading to a false reactivation if
a wakeword activation was pending before the stages' processing
of the audio buffer was interrupted.

Due to the new interface method required by this fix, it will be a major release when ready.