### PR TITLE
fix: reclaim speech context on pipeline stop

### DIFF
--- a/src/main/java/io/spokestack/spokestack/SpeechContext.java
+++ b/src/main/java/io/spokestack/spokestack/SpeechContext.java
@@ -226,6 +226,7 @@ public final class SpeechContext {
     public SpeechContext reset() {
         setSpeech(false);
         setActive(false);
+        setManaged(false);
         setTranscript("");
         setConfidence(0);
         setError(null);

--- a/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
+++ b/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
@@ -144,10 +144,16 @@ public class SpeechPipelineTest implements OnSpeechEventListener {
         assertEquals(SpeechContext.Event.DEACTIVATE, this.events.get(0));
         assertFalse(pipeline.getContext().isActive());
 
+        // third frame reactivates the context
+        transact(false);
+        assertEquals(SpeechContext.Event.ACTIVATE, this.events.get(0));
+        assertTrue(pipeline.getContext().isActive());
+
         // shutdown
         Input.stop();
         pipeline.close();
         assertFalse(pipeline.isRunning());
+        assertFalse(pipeline.getContext().isActive());
         assertEquals(-1, Input.counter);
         assertFalse(Stage.open);
     }


### PR DESCRIPTION
This fixes another issue with microphone handoff between the speech pipeline and Android's built-in ASR. Under certain conditions, it was possible to close the pipeline before the Android ASR had released control of the speech context, rendering the pipeline unable to trigger wakeword or ASR despite reporting successful activation. The speech context is now unconditionally released from external management when the pipeline is stopped, allowing input and stage processing to continue as normal if the pipeline is restarted.