### PR TITLE
fix: stop speech pipeline on audio read errors

### DIFF
--- a/src/main/java/io/spokestack/spokestack/SpeechPipeline.java
+++ b/src/main/java/io/spokestack/spokestack/SpeechPipeline.java
@@ -226,8 +226,13 @@ public final class SpeechPipeline implements AutoCloseable {
             ByteBuffer frame = this.context.getBuffer().removeFirst();
             this.context.getBuffer().addLast(frame);
 
-            // fill the frame from the input
-            this.input.read(this.context, frame);
+            // fill the frame from the input, stopping if audio cannot be read
+            try {
+                this.input.read(this.context, frame);
+            } catch (Exception e) {
+                raiseError(e);
+                stop();
+            }
 
             // when leaving the managed state, reset all stages internally
             boolean isManaged = this.context.isManaged();

--- a/src/main/java/io/spokestack/spokestack/android/AudioRecordError.java
+++ b/src/main/java/io/spokestack/spokestack/android/AudioRecordError.java
@@ -1,0 +1,52 @@
+package io.spokestack.spokestack.android;
+
+/**
+ * A simple exception class that wraps error codes from {@link
+ * android.media.AudioRecord AudioRecord}.
+ */
+public class AudioRecordError extends Exception {
+
+    /**
+     * Create a new error from a code code provided by the
+     * Android system.
+     *
+     * @param errorCode The Android system error code.
+     */
+    public AudioRecordError(int errorCode) {
+        super("AudioRecord error code " + errorCode + ": "
+              + Description.valueOf(errorCode));
+    }
+
+    /**
+     * An enumeration of the AudioRecord error descriptions aligned with
+     * their integer constant values.
+     */
+    @SuppressWarnings("checkstyle:javadocvariable")
+    public enum Description {
+        INVALID_OPERATION(-3),
+        BAD_VALUE(-2),
+        DEAD_OBJECT(-6),
+        UNKNOWN_ERROR(-1);
+
+        private final int code;
+
+        Description(int errorCode) {
+            this.code = errorCode;
+        }
+
+        /**
+         * Retrieve an error description by code.
+         *
+         * @param errorCode The Android error code.
+         * @return A description of the error based on its code.
+         */
+        public static Description valueOf(int errorCode) {
+            for (Description description : Description.values()) {
+                if (description.code == errorCode) {
+                    return description;
+                }
+            }
+            return Description.UNKNOWN_ERROR;
+        }
+    }
+}

--- a/src/main/java/io/spokestack/spokestack/android/MicrophoneInput.java
+++ b/src/main/java/io/spokestack/spokestack/android/MicrophoneInput.java
@@ -71,10 +71,14 @@ public final class MicrophoneInput implements SpeechInput {
      * reads a frame from the microphone.
      * @param context the current speech context
      * @param frame the frame buffer to fill
+     *
+     * @throws AudioRecordError if audio cannot be read
      */
-    public void read(SpeechContext context, ByteBuffer frame) {
+    public void read(SpeechContext context, ByteBuffer frame)
+          throws AudioRecordError {
         int read = this.recorder.read(frame, frame.capacity());
-        if (read != frame.capacity())
-            throw new IllegalStateException();
+        if (read != frame.capacity()) {
+            throw new AudioRecordError(read);
+        }
     }
 }

--- a/src/main/java/io/spokestack/spokestack/android/NoInput.java
+++ b/src/main/java/io/spokestack/spokestack/android/NoInput.java
@@ -22,7 +22,7 @@ public final class NoInput implements SpeechInput {
     }
 
     /**
-     * simulates reading an frame. actually does nothing.
+     * simulates reading an audio frame. actually does nothing.
      *
      * @param context the current speech context
      * @param frame   the frame buffer to fill

--- a/src/main/java/io/spokestack/spokestack/android/PreASRMicrophoneInput.java
+++ b/src/main/java/io/spokestack/spokestack/android/PreASRMicrophoneInput.java
@@ -65,8 +65,11 @@ public final class PreASRMicrophoneInput implements SpeechInput {
      *
      * @param context the current speech context
      * @param frame   the frame buffer to fill
+     *
+     * @throws AudioRecordError if audio cannot be read
      */
-    public void read(SpeechContext context, ByteBuffer frame) {
+    public void read(SpeechContext context, ByteBuffer frame)
+          throws AudioRecordError {
         if (context.isActive()) {
             stopRecording(context);
         } else {
@@ -75,7 +78,7 @@ public final class PreASRMicrophoneInput implements SpeechInput {
             }
             int read = this.recorder.read(frame, frame.capacity());
             if (read != frame.capacity()) {
-                throw new IllegalStateException();
+                throw new AudioRecordError(read);
             }
         }
     }

--- a/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
+++ b/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
@@ -6,6 +6,7 @@ import java.util.concurrent.Semaphore;
 import java.nio.ByteBuffer;
 
 import androidx.annotation.NonNull;
+import io.spokestack.spokestack.android.AudioRecordError;
 import io.spokestack.spokestack.util.EventTracer;
 import org.junit.Before;
 import org.junit.Test;
@@ -17,12 +18,15 @@ public class SpeechPipelineTest implements OnSpeechEventListener {
           io.spokestack.spokestack.profile.PushToTalkAndroidASR.class,
           io.spokestack.spokestack.profile.PushToTalkAzureASR.class,
           io.spokestack.spokestack.profile.PushToTalkGoogleASR.class,
+          io.spokestack.spokestack.profile.PushToTalkSpokestackASR.class,
           io.spokestack.spokestack.profile.TFWakewordAndroidASR.class,
           io.spokestack.spokestack.profile.TFWakewordAzureASR.class,
           io.spokestack.spokestack.profile.TFWakewordGoogleASR.class,
+          io.spokestack.spokestack.profile.TFWakewordSpokestackASR.class,
           io.spokestack.spokestack.profile.VADTriggerAndroidASR.class,
           io.spokestack.spokestack.profile.VADTriggerAzureASR.class,
-          io.spokestack.spokestack.profile.VADTriggerGoogleASR.class
+          io.spokestack.spokestack.profile.VADTriggerGoogleASR.class,
+          io.spokestack.spokestack.profile.VADTriggerSpokestackASR.class
     );
 
     private List<SpeechContext.Event> events = new ArrayList<>();
@@ -165,7 +169,11 @@ public class SpeechPipelineTest implements OnSpeechEventListener {
             .addOnSpeechEventListener(this)
             .build();
         pipeline.start();
-        pipeline.stop();
+
+        // wait for pipeline to shut down due to error
+        while (pipeline.isRunning()) {
+            Thread.sleep(1);
+        }
         assertEquals(SpeechContext.Event.ERROR, this.events.get(0));
     }
 
@@ -324,7 +332,7 @@ public class SpeechPipelineTest implements OnSpeechEventListener {
 
         public void read(SpeechContext context, ByteBuffer frame)
               throws Exception {
-            throw new Exception("fail");
+            throw new AudioRecordError(-3);
         }
     }
 

--- a/src/test/java/io/spokestack/spokestack/android/MicrophoneInputTest.java
+++ b/src/test/java/io/spokestack/spokestack/android/MicrophoneInputTest.java
@@ -2,6 +2,7 @@ import java.nio.ByteBuffer;
 
 import io.spokestack.spokestack.SpeechConfig;
 import io.spokestack.spokestack.SpeechContext;
+import io.spokestack.spokestack.android.AudioRecordError;
 import org.junit.Test;
 import org.junit.jupiter.api.function.Executable;
 import static org.junit.jupiter.api.Assertions.*;
@@ -14,7 +15,7 @@ import io.spokestack.spokestack.android.MicrophoneInput;
 
 public class MicrophoneInputTest {
     @Test
-    public void testRead() {
+    public void testRead() throws AudioRecordError {
         final AudioRecord recorder = mock(AudioRecord.class);
         final MicrophoneInput input = new MicrophoneInput(recorder);
         final ByteBuffer buffer = ByteBuffer.allocateDirect(42);
@@ -25,9 +26,7 @@ public class MicrophoneInputTest {
         // invalid read
         when(recorder.read(any(ByteBuffer.class), anyInt()))
             .thenReturn(1);
-        assertThrows(IllegalStateException.class, new Executable() {
-            public void execute() { input.read(context, buffer); }
-        });
+        assertThrows(AudioRecordError.class, () -> input.read(context, buffer));
 
         // valid read
         when(recorder.read(any(ByteBuffer.class), anyInt()))

--- a/src/test/java/io/spokestack/spokestack/android/PreASRMicrophoneInputTest.java
+++ b/src/test/java/io/spokestack/spokestack/android/PreASRMicrophoneInputTest.java
@@ -25,7 +25,7 @@ import static org.powermock.api.mockito.PowerMockito.*;
 public class PreASRMicrophoneInputTest {
 
     @Before
-    public void before() throws Exception{
+    public void before() throws Exception {
         mockStatic(AudioRecord.class);
         AudioRecord record = mock(AudioRecord.class);
         whenNew(AudioRecord.class).withAnyArguments().thenReturn(record);
@@ -38,7 +38,7 @@ public class PreASRMicrophoneInputTest {
     }
 
     @Test
-    public void testRead() {
+    public void testRead() throws AudioRecordError {
         final SpeechConfig config = new SpeechConfig();
         config.put("sample-rate", 16000);
         final PreASRMicrophoneInput input =
@@ -52,8 +52,7 @@ public class PreASRMicrophoneInputTest {
 
         // invalid read
         when(recorder.read(any(ByteBuffer.class), anyInt())).thenReturn(1);
-        assertThrows(IllegalStateException.class, () ->
-              input.read(context, buffer));
+        assertThrows(AudioRecordError.class, () -> input.read(context, buffer));
 
         verify(recorder).startRecording();
 


### PR DESCRIPTION
There are a few different reasons the microphone can fail to read audio, but I'm not sure that any of them are immediately recoverable. To avoid spamming errors to host apps in the `dispatch` loop, this change shuts down the speech pipeline on the first read error, attempting to wrap Android's opaque error codes in the closest they give us to descriptions of those errors.