### PR TITLE
change encoder reset fill values

### DIFF
--- a/src/main/java/io/spokestack/spokestack/asr/KeywordRecognizer.java
+++ b/src/main/java/io/spokestack/spokestack/asr/KeywordRecognizer.java
@@ -258,7 +258,7 @@ public final class KeywordRecognizer implements SpeechProcessor {
         this.encodeWindow = new RingBuffer(encodeLength * this.encodeWidth);
 
         this.frameWindow.fill(0);
-        this.encodeWindow.fill(0);
+        this.encodeWindow.fill(-1);
 
         // load the tensorflow-lite models
         this.filterModel = loader
@@ -296,9 +296,10 @@ public final class KeywordRecognizer implements SpeechProcessor {
         this.sampleWindow.reset();
 
         // reset and fill the other buffers,
-        // which prevents them from lagging the detection
+        // which prevents them from delaying detection
+        // the encoder has a tanh nonlinearity, so fill it with -1
         this.frameWindow.reset().fill(0);
-        this.encodeWindow.reset().fill(0);
+        this.encodeWindow.reset().fill(-1);
 
         // reset the encoder states
         while (this.encodeModel.states().hasRemaining())


### PR DESCRIPTION
The encoder models for the wakeword trigger/keyword recognizer currently use a tanh activation, and all models we have seen have their values for silence driven to the low side of the activation. We want to preserve the lag benefits of filling the encoder buffer on reset, but 0 is an unstable value for this activation, so we will now fill with -1. This reduces false activations.

I also threw in a fix for wakeword tracing that reports the final maximum posterior before activation, instead of the previous maximum.