### PR TITLE
agc enhancements

### DIFF
--- a/src/main/java/io/spokestack/spokestack/profile/PushToTalkAzureASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/PushToTalkAzureASR.java
@@ -30,10 +30,9 @@ public class PushToTalkAzureASR implements PipelineProfile {
               .setInputClass(
                     "io.spokestack.spokestack.android.MicrophoneInput")
               .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
-              .addStageClass(
                     "io.spokestack.spokestack.webrtc.AutomaticGainControl")
-              .setProperty("agc-compression-gain-db", 15)
+              .addStageClass(
+                    "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
               .addStageClass(
                     "io.spokestack.spokestack.webrtc.VoiceActivityDetector")
               .addStageClass("io.spokestack.spokestack.ActivationTimeout")

--- a/src/main/java/io/spokestack/spokestack/profile/PushToTalkGoogleASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/PushToTalkGoogleASR.java
@@ -31,10 +31,9 @@ public class PushToTalkGoogleASR implements PipelineProfile {
               .setInputClass(
                     "io.spokestack.spokestack.android.MicrophoneInput")
               .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
-              .addStageClass(
                     "io.spokestack.spokestack.webrtc.AutomaticGainControl")
-              .setProperty("agc-compression-gain-db", 15)
+              .addStageClass(
+                    "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
               .addStageClass(
                     "io.spokestack.spokestack.webrtc.VoiceActivityDetector")
               .addStageClass("io.spokestack.spokestack.ActivationTimeout")

--- a/src/main/java/io/spokestack/spokestack/profile/PushToTalkSpokestackASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/PushToTalkSpokestackASR.java
@@ -35,10 +35,9 @@ public class PushToTalkSpokestackASR implements PipelineProfile {
               .setInputClass(
                     "io.spokestack.spokestack.android.MicrophoneInput")
               .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
-              .addStageClass(
                     "io.spokestack.spokestack.webrtc.AutomaticGainControl")
-              .setProperty("agc-compression-gain-db", 15)
+              .addStageClass(
+                    "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
               .addStageClass(
                     "io.spokestack.spokestack.webrtc.VoiceActivityDetector")
               .addStageClass("io.spokestack.spokestack.ActivationTimeout")

--- a/src/main/java/io/spokestack/spokestack/profile/TFWakewordAndroidASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/TFWakewordAndroidASR.java
@@ -51,12 +51,10 @@ public class TFWakewordAndroidASR implements PipelineProfile {
               .setInputClass(
                     "io.spokestack.spokestack.android.PreASRMicrophoneInput")
               .addStageClass(
+                    "io.spokestack.spokestack.webrtc.AutomaticGainControl")
+              .addStageClass(
                     "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
               .setProperty("ans-policy", "aggressive")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AutomaticGainControl")
-              .setProperty("agc-target-level-dbfs", 3)
-              .setProperty("agc-compression-gain-db", 15)
               .addStageClass(
                     "io.spokestack.spokestack.webrtc.VoiceActivityDetector")
               .setProperty("vad-mode", "very-aggressive")

--- a/src/main/java/io/spokestack/spokestack/profile/TFWakewordAzureASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/TFWakewordAzureASR.java
@@ -57,12 +57,10 @@ public class TFWakewordAzureASR implements PipelineProfile {
               .setInputClass(
                     "io.spokestack.spokestack.android.MicrophoneInput")
               .addStageClass(
+                    "io.spokestack.spokestack.webrtc.AutomaticGainControl")
+              .addStageClass(
                     "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
               .setProperty("ans-policy", "aggressive")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AutomaticGainControl")
-              .setProperty("agc-target-level-dbfs", 3)
-              .setProperty("agc-compression-gain-db", 15)
               .addStageClass(
                     "io.spokestack.spokestack.webrtc.VoiceActivityDetector")
               .setProperty("vad-mode", "very-aggressive")

--- a/src/main/java/io/spokestack/spokestack/profile/TFWakewordGoogleASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/TFWakewordGoogleASR.java
@@ -58,12 +58,10 @@ public class TFWakewordGoogleASR implements PipelineProfile {
               .setInputClass(
                     "io.spokestack.spokestack.android.MicrophoneInput")
               .addStageClass(
+                    "io.spokestack.spokestack.webrtc.AutomaticGainControl")
+              .addStageClass(
                     "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
               .setProperty("ans-policy", "aggressive")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AutomaticGainControl")
-              .setProperty("agc-target-level-dbfs", 3)
-              .setProperty("agc-compression-gain-db", 15)
               .addStageClass(
                     "io.spokestack.spokestack.webrtc.VoiceActivityDetector")
               .setProperty("vad-mode", "very-aggressive")

--- a/src/main/java/io/spokestack/spokestack/profile/TFWakewordSpokestackASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/TFWakewordSpokestackASR.java
@@ -63,12 +63,10 @@ public class TFWakewordSpokestackASR implements PipelineProfile {
               .setInputClass(
                     "io.spokestack.spokestack.android.MicrophoneInput")
               .addStageClass(
+                    "io.spokestack.spokestack.webrtc.AutomaticGainControl")
+              .addStageClass(
                     "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
               .setProperty("ans-policy", "aggressive")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AutomaticGainControl")
-              .setProperty("agc-target-level-dbfs", 3)
-              .setProperty("agc-compression-gain-db", 15)
               .addStageClass(
                     "io.spokestack.spokestack.webrtc.VoiceActivityDetector")
               .setProperty("vad-mode", "very-aggressive")

--- a/src/main/java/io/spokestack/spokestack/profile/VADTriggerAndroidASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/VADTriggerAndroidASR.java
@@ -23,10 +23,9 @@ public class VADTriggerAndroidASR implements PipelineProfile {
               .setInputClass(
                     "io.spokestack.spokestack.android.PreASRMicrophoneInput")
               .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
-              .addStageClass(
                     "io.spokestack.spokestack.webrtc.AutomaticGainControl")
-              .setProperty("agc-compression-gain-db", 15)
+              .addStageClass(
+                    "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
               .addStageClass(
                     "io.spokestack.spokestack.webrtc.VoiceActivityDetector")
               .addStageClass(

--- a/src/main/java/io/spokestack/spokestack/profile/VADTriggerAzureASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/VADTriggerAzureASR.java
@@ -30,10 +30,9 @@ public class VADTriggerAzureASR implements PipelineProfile {
               .setInputClass(
                     "io.spokestack.spokestack.android.MicrophoneInput")
               .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
-              .addStageClass(
                     "io.spokestack.spokestack.webrtc.AutomaticGainControl")
-              .setProperty("agc-compression-gain-db", 15)
+              .addStageClass(
+                    "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
               .addStageClass(
                     "io.spokestack.spokestack.webrtc.VoiceActivityDetector")
               .addStageClass(

--- a/src/main/java/io/spokestack/spokestack/profile/VADTriggerGoogleASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/VADTriggerGoogleASR.java
@@ -29,10 +29,9 @@ public class VADTriggerGoogleASR implements PipelineProfile {
               .setInputClass(
                     "io.spokestack.spokestack.android.MicrophoneInput")
               .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
-              .addStageClass(
                     "io.spokestack.spokestack.webrtc.AutomaticGainControl")
-              .setProperty("agc-compression-gain-db", 15)
+              .addStageClass(
+                    "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
               .addStageClass(
                     "io.spokestack.spokestack.webrtc.VoiceActivityDetector")
               .addStageClass(

--- a/src/main/java/io/spokestack/spokestack/profile/VADTriggerSpokestackASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/VADTriggerSpokestackASR.java
@@ -35,10 +35,9 @@ public class VADTriggerSpokestackASR implements PipelineProfile {
               .setInputClass(
                     "io.spokestack.spokestack.android.MicrophoneInput")
               .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
-              .addStageClass(
                     "io.spokestack.spokestack.webrtc.AutomaticGainControl")
-              .setProperty("agc-compression-gain-db", 15)
+              .addStageClass(
+                    "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
               .addStageClass(
                     "io.spokestack.spokestack.webrtc.VoiceActivityDetector")
               .addStageClass(

--- a/src/main/java/io/spokestack/spokestack/webrtc/AutomaticGainControl.java
+++ b/src/main/java/io/spokestack/spokestack/webrtc/AutomaticGainControl.java
@@ -44,7 +44,7 @@ public class AutomaticGainControl implements SpeechProcessor {
     /** default target peak amplitude, in dBFS. */
     public static final int DEFAULT_TARGET_LEVEL_DBFS = 3;
     /** default compression gain, in dB. */
-    public static final int DEFAULT_COMPRESSION_GAIN_DB = 9;
+    public static final int DEFAULT_COMPRESSION_GAIN_DB = 15;
 
     // native agc structure handle
     private final long agcHandle;
@@ -89,7 +89,11 @@ public class AutomaticGainControl implements SpeechProcessor {
             DEFAULT_COMPRESSION_GAIN_DB);
 
         // create the native agc context
-        this.agcHandle = create(rate, targetLeveldBFS, compressionGaindB, true);
+        this.agcHandle = create(
+            rate,
+            targetLeveldBFS,
+            compressionGaindB,
+            false);
         if (this.agcHandle == 0)
             throw new OutOfMemoryError();
     }

--- a/src/test/java/io/spokestack/spokestack/webrtc/AutomaticGainControlTest.java
+++ b/src/test/java/io/spokestack/spokestack/webrtc/AutomaticGainControlTest.java
@@ -78,7 +78,7 @@ public class AutomaticGainControlTest {
             .put("sample-rate", 8000)
             .put("frame-width", 10)
             .put("agc-target-level-dbfs", 9)
-            .put("agc-compression-gain-db", 2);
+            .put("agc-compression-gain-db", 15);
 
         final SpeechContext context = new SpeechContext(config);
         AutomaticGainControl agc;


### PR DESCRIPTION
These changes modify the automatic gain control to call webrtc's virtualmic function, which is apparently required for measuring current levels, in spite of the comments. The defaults for AGC have also been tuned to match the levels reported on the iPhone in this new configuration. The AGC hard limiter has also been disabled, because it clips at the target level, which is undesirable when the target level is below full scale.

The AGC has been modified to be placed by default before the noise suppressor, which in my tests gave better noise filtering. This change has been applied to all profiles and should be applied in applications that don't use profiles.