### PR TITLE
fix: Revert active-min/max config keys for RN

### DIFF
--- a/src/main/java/io/spokestack/spokestack/ActivationTimeout.java
+++ b/src/main/java/io/spokestack/spokestack/ActivationTimeout.java
@@ -21,12 +21,12 @@ import java.nio.ByteBuffer;
  *
  * <ul>
  *   <li>
- *      <b>active-min</b> (integer): the minimum length of an
+ *      <b>wake-active-min</b> (integer): the minimum length of an
  *      activation, in milliseconds, used to ignore a VAD deactivation after
  *      the manual activation
  *   </li>
  *   <li>
- *      <b>active-max</b> (integer): the maximum length of an
+ *      <b>wake-active-max</b> (integer): the maximum length of an
  *      activation, in milliseconds, used to time out the activation
  *   </li>
  * </ul>
@@ -48,10 +48,10 @@ public final class ActivationTimeout implements SpeechProcessor {
      */
     public ActivationTimeout(SpeechConfig config) {
         int frameWidth = config.getInteger("frame-width");
-        this.minActive = config.getInteger("active-min", DEFAULT_ACTIVE_MIN)
-              / frameWidth;
-        this.maxActive = config.getInteger("active-max", DEFAULT_ACTIVE_MAX)
-              / frameWidth;
+        this.minActive = config
+              .getInteger("wake-active-min", DEFAULT_ACTIVE_MIN) / frameWidth;
+        this.maxActive = config
+              .getInteger("wake-active-max", DEFAULT_ACTIVE_MAX) / frameWidth;
     }
 
     @Override

--- a/src/main/java/io/spokestack/spokestack/android/AndroidSpeechRecognizer.java
+++ b/src/main/java/io/spokestack/spokestack/android/AndroidSpeechRecognizer.java
@@ -63,7 +63,7 @@ import java.util.ArrayList;
  * </p>
  * <ul>
  *   <li>
- *      <b>active-min</b> (integer): the minimum length of time, in
+ *      <b>wake-active-min</b> (integer): the minimum length of time, in
  *      milliseconds, that the recognizer will wait for speech before timing
  *      out.
  *   </li>
@@ -82,10 +82,9 @@ public class AndroidSpeechRecognizer implements SpeechProcessor {
      *
      * @param speechConfig Spokestack pipeline configuration
      */
-    @SuppressWarnings("unused")
     public AndroidSpeechRecognizer(SpeechConfig speechConfig) {
         this.streaming = false;
-        this.minActive = speechConfig.getInteger("active-min", 0);
+        this.minActive = speechConfig.getInteger("wake-active-min", 0);
         this.taskHandler = new TaskHandler(true);
     }
 

--- a/src/main/java/io/spokestack/spokestack/profile/TFWakewordAzureASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/TFWakewordAzureASR.java
@@ -70,7 +70,7 @@ public class TFWakewordAzureASR implements PipelineProfile {
               .setProperty("wake-threshold", 0.9)
               .setProperty("pre-emphasis", 0.97)
               .addStageClass("io.spokestack.spokestack.ActivationTimeout")
-              .setProperty("active-min", 2000)
+              .setProperty("wake-active-min", 2000)
               .addStageClass(
                     "io.spokestack.spokestack.microsoft.AzureSpeechRecognizer");
     }

--- a/src/main/java/io/spokestack/spokestack/profile/TFWakewordGoogleASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/TFWakewordGoogleASR.java
@@ -71,7 +71,7 @@ public class TFWakewordGoogleASR implements PipelineProfile {
               .setProperty("wake-threshold", 0.9)
               .setProperty("pre-emphasis", 0.97)
               .addStageClass("io.spokestack.spokestack.ActivationTimeout")
-              .setProperty("active-min", 2000)
+              .setProperty("wake-active-min", 2000)
               .addStageClass(
                     "io.spokestack.spokestack.google.GoogleSpeechRecognizer");
     }

--- a/src/main/java/io/spokestack/spokestack/profile/TFWakewordSpokestackASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/TFWakewordSpokestackASR.java
@@ -76,7 +76,7 @@ public class TFWakewordSpokestackASR implements PipelineProfile {
               .setProperty("wake-threshold", 0.9)
               .setProperty("pre-emphasis", 0.97)
               .addStageClass("io.spokestack.spokestack.ActivationTimeout")
-              .setProperty("active-min", 2000)
+              .setProperty("wake-active-min", 2000)
               .addStageClass(
                     "io.spokestack.spokestack.asr.SpokestackCloudRecognizer");
     }

--- a/src/main/java/io/spokestack/spokestack/wakeword/WakewordTrigger.java
+++ b/src/main/java/io/spokestack/spokestack/wakeword/WakewordTrigger.java
@@ -92,14 +92,6 @@ import java.nio.ByteBuffer;
  *      [encode-length, encode-width], and its outputs [1]
  *   </li>
  *   <li>
- *      <b>wake-active-min</b> (integer): the minimum length of an activation,
- *      in milliseconds, used to ignore a VAD deactivation after the wakeword
- *   </li>
- *   <li>
- *      <b>wake-active-max</b> (integer): the maximum length of an activation,
- *      in milliseconds, used to time out the activation
- *   </li>
- *   <li>
  *      <b>rms-target</b> (double): the desired linear Root Mean Squared (RMS)
  *      signal energy, which is used for signal normalization and should be
  *      tuned to the RMS target used during training

--- a/src/test/java/io/spokestack/spokestack/ActivationTimeoutTest.java
+++ b/src/test/java/io/spokestack/spokestack/ActivationTimeoutTest.java
@@ -71,8 +71,8 @@ public class ActivationTimeoutTest {
         return new SpeechConfig()
               .put("sample-rate", 16000)
               .put("frame-width", 10)
-              .put("active-min", 20)
-              .put("active-max", 30);
+              .put("wake-active-min", 20)
+              .put("wake-active-max", 30);
     }
 
     public class TestEnv implements OnSpeechEventListener {


### PR DESCRIPTION
This change reverts the names of the configuration parameters that control the pipeline activation length so they are reachable from the React Native library.

The renaming slid through when the activation timeout component was introduced way back when to support both wakeword and push-to-talk activations. I had originally planned to lobby for renaming the params in the RN library, but my inaction will serve as surrender.

I suppose it should be noted that only `wake-active-min` is remotely effective (and that not guaranteed) when the built-in Android ASR is in use.