### PR TITLE
Centralized setup via wrapper class

### DIFF
--- a/src/main/java/io/spokestack/spokestack/Spokestack.java
+++ b/src/main/java/io/spokestack/spokestack/Spokestack.java
@@ -1,0 +1,593 @@
+package io.spokestack.spokestack;
+
+import android.content.Context;
+import androidx.lifecycle.Lifecycle;
+import io.spokestack.spokestack.nlu.NLUResult;
+import io.spokestack.spokestack.nlu.NLUService;
+import io.spokestack.spokestack.nlu.tensorflow.TensorflowNLU;
+import io.spokestack.spokestack.tts.SynthesisRequest;
+import io.spokestack.spokestack.tts.TTSManager;
+import io.spokestack.spokestack.util.AsyncResult;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class combines all Spokestack subsystems into a single component to
+ * provide a unified interface to the library's ASR, NLU, and TTS features. Like
+ * the individual subsystems, it is configurable using a fluent builder pattern,
+ * but it provides a default configuration; only a few parameters are required
+ * from the calling application, and those only for specific features noted in
+ * the documentation for the builder's methods.
+ *
+ * <p>
+ * Client applications may wish to establish event listeners for purposes such
+ * as logging, but events necessary to forward user interactions through the
+ * system (for example, sending ASR transcripts through NLU) are handled
+ * entirely by this class. This includes internal management of TTS playback,
+ * which requires the client application to declare additional media player
+ * dependencies; see
+ * <a href="https://www.spokestack.io/docs/Android/tts#prerequisites">the
+ * documentation</a> for more details. This feature can be disabled via the
+ * builder if desired.
+ * </p>
+ *
+ * <p>
+ * In general, the default configuration assumes that the client application
+ * wants to use all of Spokestack's features, regardless of their implied
+ * dependencies or required configuration, so an error will be thrown if any
+ * prerequisite is missing at build time. Individual features can be disabled
+ * via the builder.
+ * </p>
+ *
+ * <p>
+ * Convenience methods are provided to interact with the most important features
+ * of individual subsystems, but they do not completely duplicate the
+ * subsystems' public APIs. Each subsystem in use can be retrieved via its own
+ * getter, enabling use of its full API.
+ * </p>
+ *
+ * <p>
+ * Any convenience methods called on a subsystem that has been explicitly
+ * disabled will result in a {@code NullPointerException}.
+ * </p>
+ *
+ * <p>
+ * This class is not threadsafe; public methods used to interact with Spokestack
+ * subsystems should be called from the same thread. The subsystems themselves
+ * use background threads where appropriate to perform intensive tasks.
+ * </p>
+ *
+ * @see SpeechPipeline
+ * @see TensorflowNLU
+ * @see TTSManager
+ */
+public final class Spokestack extends SpokestackAdapter
+      implements AutoCloseable {
+
+    private final List<SpokestackAdapter> listeners;
+    private SpeechPipeline speechPipeline;
+    private TensorflowNLU nlu;
+    private TTSManager tts;
+
+    /**
+     * Construct a new Spokestack wrapper from an existing builder.
+     *
+     * @param builder The builder used to construct the Spokestack wrapper.
+     * @throws Exception if there is an error during initialization.
+     */
+    private Spokestack(Builder builder) throws Exception {
+        this.listeners = new ArrayList<>();
+        this.listeners.addAll(builder.listeners);
+        if (builder.useAsr) {
+            this.speechPipeline = builder.getPipelineBuilder()
+                  .addOnSpeechEventListener(this)
+                  .build();
+        }
+        if (builder.useNLU) {
+            this.nlu = builder.getNluBuilder()
+                  .addTraceListener(this)
+                  .build();
+        }
+        if (builder.useTTS) {
+            if (!builder.useTTSPlayback) {
+                builder.ttsBuilder.setOutputClass(null);
+            }
+            this.tts = builder.getTtsBuilder()
+                  .addTTSListener(this)
+                  .build();
+        }
+    }
+
+    // speech pipeline
+
+    /**
+     * @return The speech pipeline currently in use.
+     */
+    public SpeechPipeline getSpeechPipeline() {
+        return speechPipeline;
+    }
+
+    /**
+     * Starts the speech pipeline in order to process user input via the
+     * microphone (or chosen input class).
+     *
+     * @throws Exception if there is an error configuring or starting the speech
+     *                   pipeline.
+     */
+    public void start() throws Exception {
+        this.speechPipeline.start();
+    }
+
+    /**
+     * Stops the speech pipeline and releases all its internal resources.
+     */
+    public void stop() {
+        this.speechPipeline.stop();
+    }
+
+    /**
+     * Manually activate the speech pipeline, forcing the current ASR class to
+     * begin recognizing speech. Useful when a wakeword is not employed, or in
+     * conjunction with a microphone button.
+     */
+    public void activate() {
+        this.speechPipeline.activate();
+    }
+
+    /**
+     * Manually deactivate the speech pipeline, forcing the current ASR class to
+     * stop recognizing speech. Useful in conjunction with a hold-to-talk
+     * button.
+     *
+     * <p>
+     * <b>Note</b>: This method currently has no effect on the Android speech
+     * recognizer this class uses by default.
+     * </p>
+     */
+    public void deactivate() {
+        this.speechPipeline.deactivate();
+    }
+
+    // NLU
+
+    /**
+     * @return The NLU service currently in use.
+     */
+    public NLUService getNlu() {
+        return nlu;
+    }
+
+    /**
+     * Classify a user utterance, returning a wrapper that can either block
+     * until the classification is complete or call a registered callback when
+     * the result is ready.
+     *
+     * <p>
+     * This convenience method automatically registers all {@code
+     * SpokestackAdapter}s added to this class at build time to receive the
+     * classification result asynchronously.
+     * </p>
+     *
+     * @param utterance The utterance to classify.
+     * @return An object representing the result of the asynchronous
+     * classification.
+     */
+    public AsyncResult<NLUResult> classify(String utterance) {
+        return classifyInternal(utterance);
+    }
+
+    // TTS
+
+    /**
+     * @return The TTS manager currently in use.
+     */
+    public TTSManager getTts() {
+        return tts;
+    }
+
+    /**
+     * Dynamically constructs TTS component classes, allocating any resources
+     * they control. It is only necessary to explicitly call this if the TTS
+     * subsystem's resources have been freed via {@link #releaseTts()} or {@link
+     * #close()}.
+     *
+     * @throws Exception If there is an error constructing TTS components.
+     */
+    public void prepareTts() throws Exception {
+        this.tts.prepare();
+    }
+
+    /**
+     * Stops activity in the TTS subsystem and releases any resources held by
+     * its components. No internally queued audio will be played after this
+     * method is called, and the queue will be cleared.
+     *
+     * <p>
+     * Once released, an explicit call to {@link #prepareTts()} is required to
+     * reallocate TTS resources.
+     * </p>
+     */
+    public void releaseTts() {
+        this.tts.release();
+    }
+
+    /**
+     * Synthesizes a piece of text or SSML, dispatching the result to any
+     * registered listeners.
+     *
+     * @param request The synthesis request data.
+     */
+    public void synthesize(SynthesisRequest request) {
+        this.tts.synthesize(request);
+    }
+
+    /**
+     * Stops playback of any playing or queued synthesis results.
+     */
+    public void stopPlayback() {
+        this.tts.stopPlayback();
+    }
+
+    // listeners
+
+    @Override
+    public void onEvent(@NotNull SpeechContext.Event event,
+                        @NotNull SpeechContext context) {
+        // automatically classify final ASR transcripts
+        if (event == SpeechContext.Event.RECOGNIZE) {
+            if (this.nlu != null) {
+                classifyInternal(context.getTranscript());
+            }
+        }
+    }
+
+    private AsyncResult<NLUResult> classifyInternal(String text) {
+        AsyncResult<NLUResult> result =
+              this.nlu.classify(text);
+        result.registerCallback(this);
+        for (SpokestackAdapter listener : this.listeners) {
+            result.registerCallback(listener);
+        }
+        return result;
+    }
+
+    @Override
+    public void close() {
+        if (this.speechPipeline != null) {
+            this.speechPipeline.close();
+        }
+        if (this.tts != null) {
+            this.tts.close();
+        }
+    }
+
+    /**
+     * Fluent builder interface for configuring Spokestack.
+     *
+     * @see Spokestack
+     * @see Builder#Builder()
+     */
+    public static class Builder {
+        private final SpeechConfig speechConfig;
+        private final SpeechPipeline.Builder pipelineBuilder;
+        private final TensorflowNLU.Builder nluBuilder;
+        private final TTSManager.Builder ttsBuilder;
+        private final List<SpokestackAdapter> listeners = new ArrayList<>();
+
+        private boolean useAsr = true;
+        private boolean useNLU = true;
+        private boolean useTTS = true;
+        private boolean useTTSPlayback = true;
+
+        private Context appContext;
+        private Lifecycle appLifecycle;
+
+        /**
+         * Create a Spokestack builder with a default configuration. The speech
+         * pipeline will use the {@link
+         * io.spokestack.spokestack.profile.TFWakewordAndroidASR
+         * TFWakewordAndroidASR} profile, and all features will be enabled.
+         *
+         * <p>
+         * Internally, this builder delegates to the builder APIs of individual
+         * subsystems. These individual builders can be retrieved and customized
+         * as desired. Calls to {@link #setProperty(String, Object)} are
+         * propagated to all subsystems.
+         * </p>
+         *
+         * <p>
+         * Some subsystems require additional configuration that cannot be set
+         * automatically. Properties are set via {@link #setProperty(String,
+         * Object)}; other configuration is listed by method:
+         * </p>
+         *
+         * <ul>
+         *     <li>
+         *         Wakeword detection (properties)
+         *     <ul>
+         *   <li>
+         *      <b>wake-filter-path</b> (string): file system path to the
+         *      "filter" Tensorflow Lite model.
+         *   </li>
+         *   <li>
+         *      <b>wake-encode-path</b> (string): file system path to the
+         *      "encode" Tensorflow Lite model.
+         *   </li>
+         *   <li>
+         *      <b>wake-detect-path</b> (string): file system path to the
+         *      "detect" Tensorflow Lite model.
+         *   </li>
+         *     </ul>
+         *     </li>
+         *     <li>
+         *         NLU (properties)
+         *     <ul>
+         *   <li>
+         *      <b>nlu-model-path</b> (string): file system path to the NLU
+         *      TensorFlow Lite model.
+         *   </li>
+         *   <li>
+         *      <b>nlu-metadata-path</b> (string): file system path to the
+         *      model's metadata, used to decode intent and slot names and
+         *      types.
+         *   </li>
+         *   <li>
+         *      <b>wordpiece-vocab-path</b> (string): file system path to the
+         *      wordpiece vocabulary file used by the wordpiece token encoder.
+         *   </li>
+         *     </ul>
+         *     </li>
+         *     <li>
+         *         TTS (properties)
+         *     <ul>
+         *   <li>
+         *      <b>spokestack-id</b> (string): client ID used to authorize TTS
+         *      requests; see <a href="https://spokestack.io/account">
+         *          https://spokestack.io/account</a>.
+         *   </li>
+         *   <li>
+         *      <b>spokestack-secret</b> (string): client secret used to
+         *      authorize TTS requests; see
+         *      <a href="https://spokestack.io/account">
+         *          https://spokestack.io/account</a>.
+         *   </li>
+         *   </ul>
+         *     </li>
+         *     <li>
+         *         TTS (other)
+         *     <ul>
+         *   <li>
+         *       {@link #setAndroidContext(android.content.Context)}:
+         *       Android Application context used to manage the audio session
+         *       for automatic playback.
+         *   </li>
+         *   <li>
+         *       {@link #setLifecycle(androidx.lifecycle.Lifecycle)}:
+         *       Android lifecycle context used to manage automatic pausing and
+         *       resuming of audio on application lifecycle events.
+         *   </li>
+         *   </ul>
+         *     </li>
+         * </ul>
+         */
+        public Builder() {
+            this.speechConfig = new SpeechConfig();
+            String profileClass =
+                  "io.spokestack.spokestack.profile.TFWakewordAndroidASR";
+            this.pipelineBuilder =
+                  new SpeechPipeline.Builder()
+                        .setConfig(this.speechConfig)
+                        .useProfile(profileClass);
+            this.nluBuilder =
+                  new TensorflowNLU.Builder().setConfig(this.speechConfig);
+            String ttsServiceClass =
+                  "io.spokestack.spokestack.tts.SpokestackTTSService";
+            String ttsOutputClass =
+                  "io.spokestack.spokestack.tts.SpokestackTTSOutput";
+            this.ttsBuilder =
+                  new TTSManager.Builder()
+                        .setTTSServiceClass(ttsServiceClass)
+                        .setOutputClass(ttsOutputClass)
+                        .setConfig(this.speechConfig);
+        }
+
+        /**
+         * Construct a wrapper builder with specific subsystem builders. Used
+         * for testing.
+         *
+         * @param pipeline the speech pipeline builder
+         * @param nlu      the NLU builder
+         * @param tts      the TTS builder
+         */
+        Builder(SpeechPipeline.Builder pipeline, TensorflowNLU.Builder nlu,
+                TTSManager.Builder tts) {
+            this.speechConfig = new SpeechConfig();
+            this.pipelineBuilder = pipeline;
+            this.nluBuilder = nlu;
+            this.ttsBuilder = tts;
+        }
+
+        /**
+         * @return The builder used to configure the speech pipeline.
+         */
+        public SpeechPipeline.Builder getPipelineBuilder() {
+            return pipelineBuilder;
+        }
+
+        /**
+         * @return The builder used to configure the NLU subsystem.
+         */
+        public TensorflowNLU.Builder getNluBuilder() {
+            return nluBuilder;
+        }
+
+        /**
+         * @return The builder used to configure the TTS subsystem.
+         */
+        public TTSManager.Builder getTtsBuilder() {
+            return ttsBuilder;
+        }
+
+        /**
+         * Sets configuration for all subsystem builders.
+         *
+         * @param config configuration to attach
+         * @return the updated builder
+         */
+        public Builder setConfig(SpeechConfig config) {
+            this.pipelineBuilder.setConfig(config);
+            this.nluBuilder.setConfig(config);
+            this.ttsBuilder.setConfig(config);
+            return this;
+        }
+
+        /**
+         * Sets a configuration value.
+         *
+         * @param key   Configuration property name
+         * @param value Property value
+         * @return the updated builder
+         */
+        public Builder setProperty(String key, Object value) {
+            this.speechConfig.put(key, value);
+            return this;
+        }
+
+        /**
+         * Sets the Android Context for the pipeline. Should be an Application
+         * Context rather than an Activity Context.
+         *
+         * @param androidContext the Android Application Context.
+         * @return the updated builder
+         */
+        public Builder setAndroidContext(Context androidContext) {
+            this.appContext = androidContext;
+            this.pipelineBuilder.setAndroidContext(androidContext);
+            this.ttsBuilder.setAndroidContext(androidContext);
+            return this;
+        }
+
+        /**
+         * Sets the Android Lifecycle used for management of TTS playback.
+         *
+         * @param lifecycle the Android Lifecycle.
+         * @return the updated builder
+         */
+        public Builder setLifecycle(Lifecycle lifecycle) {
+            this.appLifecycle = lifecycle;
+            this.ttsBuilder.setLifecycle(lifecycle);
+            return this;
+        }
+
+        /**
+         * Signal that Spokestack's speech pipeline should not be used to
+         * recognize speech.
+         *
+         * @return the updated builder
+         */
+        public Builder disableAsr() {
+            this.useAsr = false;
+            return this;
+        }
+
+        /**
+         * Signal that Spokestack's TensorFlow Lite wakeword detector should not
+         * be used. This is equivalent to calling
+         * <pre>
+         * builder
+         *     .getPipelineBuilder()
+         *     .useProfile(
+         *         "io.spokestack.spokestack.profile.PushToTalkAndroidASR");
+         * </pre>
+         * <p>
+         * If a different profile is specified using the above approach, or if
+         * the speech pipeline is disabled altogether with {@link
+         * #disableAsr()}, this method should not be called.
+         *
+         * @return the updated builder
+         */
+        public Builder disableWakeword() {
+            String profileClass =
+                  "io.spokestack.spokestack.profile.PushToTalkAndroidASR";
+            this.pipelineBuilder.useProfile(profileClass);
+            return this;
+        }
+
+        /**
+         * Signal that Spokestack's NLU subsystem should not be used.
+         *
+         * @return the updated builder
+         */
+        public Builder disableNlu() {
+            this.useNLU = false;
+            return this;
+        }
+
+        /**
+         * Signal that Spokestack's TTS subsystem should not be used.
+         *
+         * @return the updated builder
+         */
+        public Builder disableTts() {
+            this.useTTS = false;
+            return this;
+        }
+
+        /**
+         * Signal that Spokestack should not automatically manage TTS playback.
+         * To disable TTS altogether, call {@link #disableTts()}; calling both
+         * is unnecessary.
+         *
+         * @return the updated builder
+         */
+        public Builder disableTtsPlayback() {
+            this.useTTSPlayback = false;
+            return this;
+        }
+
+        /**
+         * Add a listener that receives events from all subsystems. This method
+         * is provided as a convenience; if desired, specific listeners can
+         * still be added by retrieving the relevant subsystem builder and
+         * adding a purpose-built listener to it.
+         *
+         * @param listener A listener that will receive events from all
+         *                 Spokestack subsystems.
+         * @return the updated builder
+         */
+        public Builder addListener(SpokestackAdapter listener) {
+            this.pipelineBuilder.addOnSpeechEventListener(listener);
+            this.nluBuilder.addTraceListener(listener);
+            this.ttsBuilder.addTTSListener(listener);
+            this.listeners.add(listener);
+            return this;
+        }
+
+        /**
+         * Use the current state of the builder to construct a full Spokestack
+         * system.
+         *
+         * @return A Spokestack system configured with the current state of the
+         * builder.
+         * @throws Exception if required configuration is missing, or there is
+         *                   an error during Spokestack initialization.
+         */
+        public Spokestack build() throws Exception {
+            if (useTTS && useTTSPlayback) {
+                if (this.appContext == null) {
+                    throw new IllegalArgumentException("app context is "
+                          + "required for playback management; see"
+                          + "TTSManager.Builder.setAndroidContext()");
+                }
+                if (this.appLifecycle == null) {
+                    throw new IllegalArgumentException("app lifecycle is "
+                          + "required for playback management; see"
+                          + "TTSManager.Builder.setLifecycle()");
+                }
+            }
+            return new Spokestack(this);
+        }
+    }
+}

--- a/src/main/java/io/spokestack/spokestack/Spokestack.java
+++ b/src/main/java/io/spokestack/spokestack/Spokestack.java
@@ -28,18 +28,18 @@ import static io.spokestack.spokestack.SpeechPipeline.DEFAULT_SAMPLE_RATE;
  *
  * <p>
  * Client applications may wish to establish event listeners for purposes such
- * as logging, but events necessary to forward user interactions through the
- * system (for example, sending ASR transcripts through NLU) are handled
- * entirely by this class. This includes internal management of TTS playback,
- * which requires the client application to declare additional media player
- * dependencies; see
+ * as forwarding trace events to a logging framework, but events necessary to
+ * complete user interactions (for example, sending ASR transcripts through NLU)
+ * are handled entirely by this class. This includes internal management of TTS
+ * playback, which requires the client application to declare additional media
+ * player dependencies; see
  * <a href="https://www.spokestack.io/docs/Android/tts#prerequisites">the
  * documentation</a> for more details. This feature can be disabled via the
  * builder if desired.
  * </p>
  *
  * <p>
- * In general, the default configuration assumes that the client application
+ * The default configuration of this class assumes that the client application
  * wants to use all of Spokestack's features, regardless of their implied
  * dependencies or required configuration, so an error will be thrown if any
  * prerequisite is missing at build time. Individual features can be disabled
@@ -459,6 +459,18 @@ public final class Spokestack extends SpokestackAdapter
         /**
          * Sets configuration for all subsystem builders.
          *
+         * <p>
+         * Note that the following low-level properties are set to default
+         * values at builder construction time; these properties must have
+         * values in order for Spokestack to start properly:
+         * </p>
+         *
+         * <ul>
+         *     <li>sample-rate</li>
+         *     <li>frame-width</li>
+         *     <li>buffer-width</li>
+         * </ul>
+         *
          * @param config configuration to attach
          * @return the updated builder
          */
@@ -486,6 +498,13 @@ public final class Spokestack extends SpokestackAdapter
          * are classified by the NLU subsystem.
          *
          * <p>
+         * This can be used to alter ASR results that frequently contain a
+         * spelling for a homophone that's incorrect for the domain; for
+         * example, an app used to summon a genie whose ASR transcripts tend to
+         * contain "Jen" instead of "djinn".
+         * </p>
+         *
+         * <p>
          * If a transcript editor is in use, registered listeners will receive
          * {@code RECOGNIZE} events from the speech pipeline with the unedited
          * transcripts, but the editor will automatically run on those
@@ -495,7 +514,7 @@ public final class Spokestack extends SpokestackAdapter
          * </p>
          *
          * <p>
-         * Transcript editors are <i>not</i> automatically run on inputs to the
+         * Transcript editors are <i>not</i> run automatically on inputs to the
          * {@link #classify(String)} convenience method.
          * </p>
          *
@@ -540,7 +559,7 @@ public final class Spokestack extends SpokestackAdapter
          *
          * @return the updated builder
          */
-        public Builder disableAsr() {
+        public Builder withoutSpeechPipeline() {
             this.useAsr = false;
             return this;
         }
@@ -557,11 +576,11 @@ public final class Spokestack extends SpokestackAdapter
          * <p>
          * If a different profile is specified using the above approach, or if
          * the speech pipeline is disabled altogether with {@link
-         * #disableAsr()}, this method should not be called.
+         * #withoutSpeechPipeline()}, this method should not be called.
          *
          * @return the updated builder
          */
-        public Builder disableWakeword() {
+        public Builder withoutWakeword() {
             String profileClass =
                   "io.spokestack.spokestack.profile.PushToTalkAndroidASR";
             this.pipelineBuilder.useProfile(profileClass);
@@ -573,7 +592,7 @@ public final class Spokestack extends SpokestackAdapter
          *
          * @return the updated builder
          */
-        public Builder disableNlu() {
+        public Builder withoutNlu() {
             this.useNLU = false;
             return this;
         }
@@ -582,11 +601,11 @@ public final class Spokestack extends SpokestackAdapter
          * Signal that Spokestack's NLU subsystem should not be automatically
          * run on ASR transcripts. NLU will still be initialized and available
          * from the {@code Spokestack} instance unless explicitly disabled via
-         * {@link #disableNlu()}.
+         * {@link #withoutNlu()}.
          *
          * @return the updated builder
          */
-        public Builder disableAutoClassification() {
+        public Builder withoutAutoClassification() {
             this.autoClassify = false;
             return this;
         }
@@ -596,19 +615,19 @@ public final class Spokestack extends SpokestackAdapter
          *
          * @return the updated builder
          */
-        public Builder disableTts() {
+        public Builder withoutTts() {
             this.useTTS = false;
             return this;
         }
 
         /**
          * Signal that Spokestack should not automatically manage TTS playback.
-         * To disable TTS altogether, call {@link #disableTts()}; calling both
+         * To disable TTS altogether, call {@link #withoutTts()}; calling both
          * is unnecessary.
          *
          * @return the updated builder
          */
-        public Builder disableTtsPlayback() {
+        public Builder withoutAutoPlayback() {
             this.useTTSPlayback = false;
             return this;
         }

--- a/src/main/java/io/spokestack/spokestack/Spokestack.java
+++ b/src/main/java/io/spokestack/spokestack/Spokestack.java
@@ -8,10 +8,15 @@ import io.spokestack.spokestack.nlu.tensorflow.TensorflowNLU;
 import io.spokestack.spokestack.tts.SynthesisRequest;
 import io.spokestack.spokestack.tts.TTSManager;
 import io.spokestack.spokestack.util.AsyncResult;
+import io.spokestack.spokestack.util.EventTracer;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static io.spokestack.spokestack.SpeechPipeline.DEFAULT_BUFFER_WIDTH;
+import static io.spokestack.spokestack.SpeechPipeline.DEFAULT_FRAME_WIDTH;
+import static io.spokestack.spokestack.SpeechPipeline.DEFAULT_SAMPLE_RATE;
 
 /**
  * This class combines all Spokestack subsystems into a single component to
@@ -297,8 +302,7 @@ public final class Spokestack extends SpokestackAdapter
 
         /**
          * Create a Spokestack builder with a default configuration. The speech
-         * pipeline will use the {@link
-         * io.spokestack.spokestack.profile.TFWakewordAndroidASR
+         * pipeline will use the {@link io.spokestack.spokestack.profile.TFWakewordAndroidASR
          * TFWakewordAndroidASR} profile, and all features will be enabled.
          *
          * <p>
@@ -385,6 +389,7 @@ public final class Spokestack extends SpokestackAdapter
          */
         public Builder() {
             this.speechConfig = new SpeechConfig();
+            setDefaults(this.speechConfig);
             String profileClass =
                   "io.spokestack.spokestack.profile.TFWakewordAndroidASR";
             this.pipelineBuilder =
@@ -402,6 +407,16 @@ public final class Spokestack extends SpokestackAdapter
                         .setTTSServiceClass(ttsServiceClass)
                         .setOutputClass(ttsOutputClass)
                         .setConfig(this.speechConfig);
+        }
+
+        private void setDefaults(SpeechConfig config) {
+            // speech pipeline
+            config.put("sample-rate", DEFAULT_SAMPLE_RATE);
+            config.put("frame-width", DEFAULT_FRAME_WIDTH);
+            config.put("buffer-width", DEFAULT_BUFFER_WIDTH);
+
+            // NLU
+            config.put("trace-level", EventTracer.Level.ERROR.value());
         }
 
         /**
@@ -480,8 +495,8 @@ public final class Spokestack extends SpokestackAdapter
          * </p>
          *
          * <p>
-         * Transcript editors are <i>not</i> automatically run on inputs to
-         * the {@link #classify(String)} convenience method.
+         * Transcript editors are <i>not</i> automatically run on inputs to the
+         * {@link #classify(String)} convenience method.
          * </p>
          *
          * @param editor A transcript editor used to alter ASR results before

--- a/src/main/java/io/spokestack/spokestack/SpokestackAdapter.java
+++ b/src/main/java/io/spokestack/spokestack/SpokestackAdapter.java
@@ -1,0 +1,50 @@
+package io.spokestack.spokestack;
+
+import io.spokestack.spokestack.nlu.NLUResult;
+import io.spokestack.spokestack.nlu.TraceListener;
+import io.spokestack.spokestack.tts.TTSEvent;
+import io.spokestack.spokestack.tts.TTSListener;
+import io.spokestack.spokestack.util.Callback;
+import io.spokestack.spokestack.util.EventTracer;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * An abstract adapter class for receiving events from Spokestack subsystems.
+ *
+ * <p>
+ * This class provides empty implementations of all Spokestack listener methods.
+ * It can be extended and individual methods overridden to receive only those
+ * events.
+ * </p>
+ */
+public abstract class SpokestackAdapter implements
+      Callback<NLUResult>,
+      OnSpeechEventListener,
+      TraceListener,
+      TTSListener {
+
+    @Override
+    public void onEvent(@NotNull SpeechContext.Event event,
+                        @NotNull SpeechContext context) throws Exception {
+    }
+
+    @Override
+    public void onTrace(@NotNull EventTracer.Level level,
+                        @NotNull String message) {
+    }
+
+    @Override
+    public void eventReceived(@NotNull TTSEvent event) {
+
+    }
+
+    @Override
+    public void call(@NotNull NLUResult arg) {
+
+    }
+
+    @Override
+    public void onError(@NotNull Throwable err) {
+
+    }
+}

--- a/src/main/java/io/spokestack/spokestack/SpokestackAdapter.java
+++ b/src/main/java/io/spokestack/spokestack/SpokestackAdapter.java
@@ -23,26 +23,63 @@ public abstract class SpokestackAdapter implements
       TraceListener,
       TTSListener {
 
+    /**
+     * Receive events from the speech pipeline.
+     *
+     * @param event   The name of the event that was raised.
+     * @param context The current speech context.
+     */
     @Override
     public void onEvent(@NotNull SpeechContext.Event event,
-                        @NotNull SpeechContext context) throws Exception {
+                        @NotNull SpeechContext context) {
     }
 
+    /**
+     * Receive trace messages from the NLU subsystem.
+     *
+     * @param level   The trace event's severity level.
+     * @param message the trace event's message.
+     */
     @Override
     public void onTrace(@NotNull EventTracer.Level level,
                         @NotNull String message) {
     }
 
+    /**
+     * Receive events from the TTS subsystem.
+     *
+     * @param event The event from the TTS subsystem.
+     */
     @Override
     public void eventReceived(@NotNull TTSEvent event) {
 
     }
 
+    /**
+     * Called when an NLU classification result is available if this class is
+     * registered as a callback at classification time. Adapters added to a
+     * {@link Spokestack} class at build time are automatically registered for
+     * all classifications.
+     *
+     * @param result The NLU result.
+     * @see io.spokestack.spokestack.nlu.tensorflow.TensorflowNLU#classify(String)
+     * @see io.spokestack.spokestack.util.AsyncResult
+     */
     @Override
-    public void call(@NotNull NLUResult arg) {
+    public void call(@NotNull NLUResult result) {
 
     }
 
+    /**
+     * Receive notifications of errors that occur during NLU classification if
+     * this class is registered as a callback at classification time.Adapters
+     * added to a {@link Spokestack} class at build time are automatically
+     * registered for all classifications.
+     *
+     * @param err An error generated during expected NLU classification.
+     * @see io.spokestack.spokestack.nlu.tensorflow.TensorflowNLU#classify(String)
+     * @see io.spokestack.spokestack.util.AsyncResult
+     */
     @Override
     public void onError(@NotNull Throwable err) {
 

--- a/src/main/java/io/spokestack/spokestack/TranscriptEditor.java
+++ b/src/main/java/io/spokestack/spokestack/TranscriptEditor.java
@@ -3,12 +3,20 @@ package io.spokestack.spokestack;
 /**
  * A functional interface used to edit an ASR transcript before it is passed to
  * the NLU subsystem for classification.
+ *
+ * <p>
+ * This can be used to alter ASR results that frequently contain a spelling for
+ * a homophone that's incorrect for the domain; for example, an app used to
+ * summon a genie whose ASR transcripts tend to contain "Jen" instead of
+ * "djinn".
+ * </p>
  */
 public interface TranscriptEditor {
 
     /**
      * Edit the ASR transcript to correct errors or perform other normalization
      * before NLU classification occurs.
+     *
      * @param transcript The transcript received from the ASR component.
      * @return An edited transcript.
      */

--- a/src/main/java/io/spokestack/spokestack/TranscriptEditor.java
+++ b/src/main/java/io/spokestack/spokestack/TranscriptEditor.java
@@ -1,0 +1,16 @@
+package io.spokestack.spokestack;
+
+/**
+ * A functional interface used to edit an ASR transcript before it is passed to
+ * the NLU subsystem for classification.
+ */
+public interface TranscriptEditor {
+
+    /**
+     * Edit the ASR transcript to correct errors or perform other normalization
+     * before NLU classification occurs.
+     * @param transcript The transcript received from the ASR component.
+     * @return An edited transcript.
+     */
+    String editTranscript(String transcript);
+}

--- a/src/main/java/io/spokestack/spokestack/profile/PushToTalkAndroidASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/PushToTalkAndroidASR.java
@@ -3,6 +3,9 @@ package io.spokestack.spokestack.profile;
 import io.spokestack.spokestack.PipelineProfile;
 import io.spokestack.spokestack.SpeechPipeline;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * A speech pipeline profile that relies on manual pipeline activation,
  * using Android's {@code SpeechRecognizer} API for ASR.
@@ -19,10 +22,10 @@ import io.spokestack.spokestack.SpeechPipeline;
 public class PushToTalkAndroidASR implements PipelineProfile {
     @Override
     public SpeechPipeline.Builder apply(SpeechPipeline.Builder builder) {
+        List<String> stages = new ArrayList<>();
+        stages.add("io.spokestack.spokestack.android.AndroidSpeechRecognizer");
         return builder
-              .setInputClass(
-                    "io.spokestack.spokestack.android.NoInput")
-              .addStageClass(
-                    "io.spokestack.spokestack.android.AndroidSpeechRecognizer");
+              .setInputClass("io.spokestack.spokestack.android.NoInput")
+              .setStageClasses(stages);
     }
 }

--- a/src/main/java/io/spokestack/spokestack/profile/PushToTalkAzureASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/PushToTalkAzureASR.java
@@ -3,6 +3,9 @@ package io.spokestack.spokestack.profile;
 import io.spokestack.spokestack.PipelineProfile;
 import io.spokestack.spokestack.SpeechPipeline;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * A speech pipeline profile that relies on manual pipeline activation, using
  * Azure Speech Service for ASR.
@@ -26,17 +29,15 @@ import io.spokestack.spokestack.SpeechPipeline;
 public class PushToTalkAzureASR implements PipelineProfile {
     @Override
     public SpeechPipeline.Builder apply(SpeechPipeline.Builder builder) {
+        List<String> stages = new ArrayList<>();
+        stages.add("io.spokestack.spokestack.webrtc.AutomaticGainControl");
+        stages.add("io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor");
+        stages.add("io.spokestack.spokestack.webrtc.VoiceActivityDetector");
+        stages.add("io.spokestack.spokestack.ActivationTimeout");
+        stages.add("io.spokestack.spokestack.microsoft.AzureSpeechRecognizer");
+
         return builder
-              .setInputClass(
-                    "io.spokestack.spokestack.android.MicrophoneInput")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AutomaticGainControl")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.VoiceActivityDetector")
-              .addStageClass("io.spokestack.spokestack.ActivationTimeout")
-              .addStageClass(
-                    "io.spokestack.spokestack.microsoft.AzureSpeechRecognizer");
+              .setInputClass("io.spokestack.spokestack.android.MicrophoneInput")
+              .setStageClasses(stages);
     }
 }

--- a/src/main/java/io/spokestack/spokestack/profile/PushToTalkGoogleASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/PushToTalkGoogleASR.java
@@ -3,9 +3,12 @@ package io.spokestack.spokestack.profile;
 import io.spokestack.spokestack.PipelineProfile;
 import io.spokestack.spokestack.SpeechPipeline;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
- * A speech pipeline profile that relies on manual pipeline activation,
- * using Google Speech for ASR.
+ * A speech pipeline profile that relies on manual pipeline activation, using
+ * Google Speech for ASR.
  *
  * <p>
  * Google Speech requires extra configuration, which must be added to the
@@ -27,17 +30,15 @@ import io.spokestack.spokestack.SpeechPipeline;
 public class PushToTalkGoogleASR implements PipelineProfile {
     @Override
     public SpeechPipeline.Builder apply(SpeechPipeline.Builder builder) {
+        List<String> stages = new ArrayList<>();
+        stages.add("io.spokestack.spokestack.webrtc.AutomaticGainControl");
+        stages.add("io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor");
+        stages.add("io.spokestack.spokestack.webrtc.VoiceActivityDetector");
+        stages.add("io.spokestack.spokestack.ActivationTimeout");
+        stages.add("io.spokestack.spokestack.google.GoogleSpeechRecognizer");
+
         return builder
-              .setInputClass(
-                    "io.spokestack.spokestack.android.MicrophoneInput")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AutomaticGainControl")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.VoiceActivityDetector")
-              .addStageClass("io.spokestack.spokestack.ActivationTimeout")
-              .addStageClass(
-                    "io.spokestack.spokestack.google.GoogleSpeechRecognizer");
+              .setInputClass("io.spokestack.spokestack.android.MicrophoneInput")
+              .setStageClasses(stages);
     }
 }

--- a/src/main/java/io/spokestack/spokestack/profile/PushToTalkSpokestackASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/PushToTalkSpokestackASR.java
@@ -3,9 +3,12 @@ package io.spokestack.spokestack.profile;
 import io.spokestack.spokestack.PipelineProfile;
 import io.spokestack.spokestack.SpeechPipeline;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
- * A speech pipeline profile that relies on manual pipeline activation,
- * using Spokestack's cloud-based ASR.
+ * A speech pipeline profile that relies on manual pipeline activation, using
+ * Spokestack's cloud-based ASR.
  *
  * <p>
  * Spokestack's cloud-based  ASR requires extra configuration, which must be
@@ -31,18 +34,16 @@ import io.spokestack.spokestack.SpeechPipeline;
 public class PushToTalkSpokestackASR implements PipelineProfile {
     @Override
     public SpeechPipeline.Builder apply(SpeechPipeline.Builder builder) {
+        List<String> stages = new ArrayList<>();
+        stages.add("io.spokestack.spokestack.webrtc.AutomaticGainControl");
+        stages.add("io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor");
+        stages.add("io.spokestack.spokestack.webrtc.VoiceActivityDetector");
+        stages.add("io.spokestack.spokestack.ActivationTimeout");
+        stages.add(
+              "io.spokestack.spokestack.android.SpokestackCloudRecognizer");
+
         return builder
-              .setInputClass(
-                    "io.spokestack.spokestack.android.MicrophoneInput")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AutomaticGainControl")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.VoiceActivityDetector")
-              .addStageClass("io.spokestack.spokestack.ActivationTimeout")
-              .addStageClass(
-                    "io.spokestack.spokestack.android.SpokestackCloudRecognizer"
-              );
+              .setInputClass("io.spokestack.spokestack.android.MicrophoneInput")
+              .setStageClasses(stages);
     }
 }

--- a/src/main/java/io/spokestack/spokestack/profile/TFWakewordAndroidASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/TFWakewordAndroidASR.java
@@ -3,6 +3,9 @@ package io.spokestack.spokestack.profile;
 import io.spokestack.spokestack.PipelineProfile;
 import io.spokestack.spokestack.SpeechPipeline;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * A speech pipeline profile that uses TensorFlow Lite for wakeword detection
  * and Android's {@code SpeechRecognizer} API for ASR. Properties related to
@@ -47,23 +50,21 @@ import io.spokestack.spokestack.SpeechPipeline;
 public class TFWakewordAndroidASR implements PipelineProfile {
     @Override
     public SpeechPipeline.Builder apply(SpeechPipeline.Builder builder) {
+        List<String> stages = new ArrayList<>();
+        stages.add("io.spokestack.spokestack.webrtc.AutomaticGainControl");
+        stages.add("io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor");
+        stages.add("io.spokestack.spokestack.webrtc.VoiceActivityDetector");
+        stages.add("io.spokestack.spokestack.wakeword.WakewordTrigger");
+        stages.add("io.spokestack.spokestack.android.AndroidSpeechRecognizer");
+
         return builder
               .setInputClass(
                     "io.spokestack.spokestack.android.PreASRMicrophoneInput")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AutomaticGainControl")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
               .setProperty("ans-policy", "aggressive")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.VoiceActivityDetector")
               .setProperty("vad-mode", "very-aggressive")
               .setProperty("vad-fall-delay", 800)
-              .addStageClass(
-                    "io.spokestack.spokestack.wakeword.WakewordTrigger")
               .setProperty("wake-threshold", 0.9)
               .setProperty("pre-emphasis", 0.97)
-              .addStageClass(
-                    "io.spokestack.spokestack.android.AndroidSpeechRecognizer");
+              .setStageClasses(stages);
     }
 }

--- a/src/main/java/io/spokestack/spokestack/profile/TFWakewordAzureASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/TFWakewordAzureASR.java
@@ -3,10 +3,13 @@ package io.spokestack.spokestack.profile;
 import io.spokestack.spokestack.PipelineProfile;
 import io.spokestack.spokestack.SpeechPipeline;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * A speech pipeline profile that uses TensorFlow Lite for wakeword detection
- * and Azure Speech Service for ASR. Properties related to
- * signal processing are tuned for the "Spokestack" wakeword.
+ * and Azure Speech Service for ASR. Properties related to signal processing are
+ * tuned for the "Spokestack" wakeword.
  *
  * <p>
  * Wakeword detection requires configuration to locate the models used for
@@ -53,25 +56,22 @@ import io.spokestack.spokestack.SpeechPipeline;
 public class TFWakewordAzureASR implements PipelineProfile {
     @Override
     public SpeechPipeline.Builder apply(SpeechPipeline.Builder builder) {
+        List<String> stages = new ArrayList<>();
+        stages.add("io.spokestack.spokestack.webrtc.AutomaticGainControl");
+        stages.add("io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor");
+        stages.add("io.spokestack.spokestack.webrtc.VoiceActivityDetector");
+        stages.add("io.spokestack.spokestack.wakeword.WakewordTrigger");
+        stages.add("io.spokestack.spokestack.ActivationTimeout");
+        stages.add("io.spokestack.spokestack.microsoft.AzureSpeechRecognizer");
+
         return builder
-              .setInputClass(
-                    "io.spokestack.spokestack.android.MicrophoneInput")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AutomaticGainControl")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
+              .setInputClass("io.spokestack.spokestack.android.MicrophoneInput")
               .setProperty("ans-policy", "aggressive")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.VoiceActivityDetector")
               .setProperty("vad-mode", "very-aggressive")
               .setProperty("vad-fall-delay", 800)
-              .addStageClass(
-                    "io.spokestack.spokestack.wakeword.WakewordTrigger")
               .setProperty("wake-threshold", 0.9)
               .setProperty("pre-emphasis", 0.97)
-              .addStageClass("io.spokestack.spokestack.ActivationTimeout")
               .setProperty("wake-active-min", 2000)
-              .addStageClass(
-                    "io.spokestack.spokestack.microsoft.AzureSpeechRecognizer");
+              .setStageClasses(stages);
     }
 }

--- a/src/main/java/io/spokestack/spokestack/profile/TFWakewordGoogleASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/TFWakewordGoogleASR.java
@@ -3,6 +3,9 @@ package io.spokestack.spokestack.profile;
 import io.spokestack.spokestack.PipelineProfile;
 import io.spokestack.spokestack.SpeechPipeline;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * A speech pipeline profile that uses TensorFlow Lite for wakeword detection
  * and Google Speech for ASR. Properties related to signal processing are tuned
@@ -54,25 +57,23 @@ import io.spokestack.spokestack.SpeechPipeline;
 public class TFWakewordGoogleASR implements PipelineProfile {
     @Override
     public SpeechPipeline.Builder apply(SpeechPipeline.Builder builder) {
+        List<String> stages = new ArrayList<>();
+        stages.add("io.spokestack.spokestack.webrtc.AutomaticGainControl");
+        stages.add("io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor");
+        stages.add("io.spokestack.spokestack.webrtc.VoiceActivityDetector");
+        stages.add("io.spokestack.spokestack.wakeword.WakewordTrigger");
+        stages.add("io.spokestack.spokestack.ActivationTimeout");
+        stages.add("io.spokestack.spokestack.google.GoogleSpeechRecognizer");
+
         return builder
               .setInputClass(
                     "io.spokestack.spokestack.android.MicrophoneInput")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AutomaticGainControl")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
               .setProperty("ans-policy", "aggressive")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.VoiceActivityDetector")
               .setProperty("vad-mode", "very-aggressive")
               .setProperty("vad-fall-delay", 800)
-              .addStageClass(
-                    "io.spokestack.spokestack.wakeword.WakewordTrigger")
               .setProperty("wake-threshold", 0.9)
               .setProperty("pre-emphasis", 0.97)
-              .addStageClass("io.spokestack.spokestack.ActivationTimeout")
               .setProperty("wake-active-min", 2000)
-              .addStageClass(
-                    "io.spokestack.spokestack.google.GoogleSpeechRecognizer");
+              .setStageClasses(stages);
     }
 }

--- a/src/main/java/io/spokestack/spokestack/profile/TFWakewordSpokestackASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/TFWakewordSpokestackASR.java
@@ -3,10 +3,13 @@ package io.spokestack.spokestack.profile;
 import io.spokestack.spokestack.PipelineProfile;
 import io.spokestack.spokestack.SpeechPipeline;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * A speech pipeline profile that uses TensorFlow Lite for wakeword detection
- * and Spokestack's cloud-based ASR. Properties related to signal processing
- * are tuned for the "Spokestack" wakeword.
+ * and Spokestack's cloud-based ASR. Properties related to signal processing are
+ * tuned for the "Spokestack" wakeword.
  *
  * <p>
  * Wakeword detection requires configuration to locate the models used for
@@ -52,32 +55,29 @@ import io.spokestack.spokestack.SpeechPipeline;
  *   </li>
  * </ul>
  *
- *
  * @see io.spokestack.spokestack.wakeword.WakewordTrigger
  * @see io.spokestack.spokestack.asr.SpokestackCloudRecognizer
  */
 public class TFWakewordSpokestackASR implements PipelineProfile {
     @Override
     public SpeechPipeline.Builder apply(SpeechPipeline.Builder builder) {
+        List<String> stages = new ArrayList<>();
+        stages.add("io.spokestack.spokestack.webrtc.AutomaticGainControl");
+        stages.add("io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor");
+        stages.add("io.spokestack.spokestack.webrtc.VoiceActivityDetector");
+        stages.add("io.spokestack.spokestack.wakeword.WakewordTrigger");
+        stages.add("io.spokestack.spokestack.ActivationTimeout");
+        stages.add("io.spokestack.spokestack.asr.SpokestackCloudRecognizer");
+
         return builder
               .setInputClass(
                     "io.spokestack.spokestack.android.MicrophoneInput")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AutomaticGainControl")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
               .setProperty("ans-policy", "aggressive")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.VoiceActivityDetector")
               .setProperty("vad-mode", "very-aggressive")
               .setProperty("vad-fall-delay", 800)
-              .addStageClass(
-                    "io.spokestack.spokestack.wakeword.WakewordTrigger")
               .setProperty("wake-threshold", 0.9)
               .setProperty("pre-emphasis", 0.97)
-              .addStageClass("io.spokestack.spokestack.ActivationTimeout")
               .setProperty("wake-active-min", 2000)
-              .addStageClass(
-                    "io.spokestack.spokestack.asr.SpokestackCloudRecognizer");
+              .setStageClasses(stages);
     }
 }

--- a/src/main/java/io/spokestack/spokestack/profile/VADTriggerAndroidASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/VADTriggerAndroidASR.java
@@ -3,6 +3,9 @@ package io.spokestack.spokestack.profile;
 import io.spokestack.spokestack.PipelineProfile;
 import io.spokestack.spokestack.SpeechPipeline;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * A speech pipeline profile that uses voice activity detection to activate
  * Android's {@code SpeechRecognizer} API for ASR.
@@ -10,8 +13,7 @@ import io.spokestack.spokestack.SpeechPipeline;
  * <p>
  * Using Android's built-in ASR requires that an Android {@code Context} object
  * be attached to the speech pipeline using it. This must be done separately
- * from profile application, using
- * {@link SpeechPipeline.Builder#setAndroidContext(android.content.Context)}.
+ * from profile application, using {@link SpeechPipeline.Builder#setAndroidContext(android.content.Context)}.
  * </p>
  *
  * @see io.spokestack.spokestack.android.AndroidSpeechRecognizer
@@ -19,18 +21,16 @@ import io.spokestack.spokestack.SpeechPipeline;
 public class VADTriggerAndroidASR implements PipelineProfile {
     @Override
     public SpeechPipeline.Builder apply(SpeechPipeline.Builder builder) {
+        List<String> stages = new ArrayList<>();
+        stages.add("io.spokestack.spokestack.webrtc.AutomaticGainControl");
+        stages.add("io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor");
+        stages.add("io.spokestack.spokestack.webrtc.VoiceActivityDetector");
+        stages.add("io.spokestack.spokestack.webrtc.VoiceActivityTrigger");
+        stages.add("io.spokestack.spokestack.android.AndroidSpeechRecognizer");
+
         return builder
               .setInputClass(
                     "io.spokestack.spokestack.android.PreASRMicrophoneInput")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AutomaticGainControl")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.VoiceActivityDetector")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.VoiceActivityTrigger")
-              .addStageClass(
-                    "io.spokestack.spokestack.android.AndroidSpeechRecognizer");
+              .setStageClasses(stages);
     }
 }

--- a/src/main/java/io/spokestack/spokestack/profile/VADTriggerAzureASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/VADTriggerAzureASR.java
@@ -3,9 +3,12 @@ package io.spokestack.spokestack.profile;
 import io.spokestack.spokestack.PipelineProfile;
 import io.spokestack.spokestack.SpeechPipeline;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
- * A speech pipeline profile that uses voice activity detection to activate
- * ASR via Azure Speech Service.
+ * A speech pipeline profile that uses voice activity detection to activate ASR
+ * via Azure Speech Service.
  *
  * <p>
  * Azure Speech Service requires extra configuration, which must be added to the
@@ -26,19 +29,16 @@ import io.spokestack.spokestack.SpeechPipeline;
 public class VADTriggerAzureASR implements PipelineProfile {
     @Override
     public SpeechPipeline.Builder apply(SpeechPipeline.Builder builder) {
+        List<String> stages = new ArrayList<>();
+        stages.add("io.spokestack.spokestack.webrtc.AutomaticGainControl");
+        stages.add("io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor");
+        stages.add("io.spokestack.spokestack.webrtc.VoiceActivityDetector");
+        stages.add("io.spokestack.spokestack.webrtc.VoiceActivityTrigger");
+        stages.add("io.spokestack.spokestack.ActivationTimeout");
+        stages.add("io.spokestack.spokestack.microsoft.AzureSpeechRecognizer");
+
         return builder
-              .setInputClass(
-                    "io.spokestack.spokestack.android.MicrophoneInput")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AutomaticGainControl")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.VoiceActivityDetector")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.VoiceActivityTrigger")
-              .addStageClass("io.spokestack.spokestack.ActivationTimeout")
-              .addStageClass(
-                    "io.spokestack.spokestack.microsoft.AzureSpeechRecognizer");
+              .setInputClass("io.spokestack.spokestack.android.MicrophoneInput")
+              .setStageClasses(stages);
     }
 }

--- a/src/main/java/io/spokestack/spokestack/profile/VADTriggerGoogleASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/VADTriggerGoogleASR.java
@@ -3,6 +3,9 @@ package io.spokestack.spokestack.profile;
 import io.spokestack.spokestack.PipelineProfile;
 import io.spokestack.spokestack.SpeechPipeline;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * A speech pipeline profile that uses voice activity detection to activate
  * Google Speech ASR.
@@ -25,19 +28,16 @@ import io.spokestack.spokestack.SpeechPipeline;
 public class VADTriggerGoogleASR implements PipelineProfile {
     @Override
     public SpeechPipeline.Builder apply(SpeechPipeline.Builder builder) {
+        List<String> stages = new ArrayList<>();
+        stages.add("io.spokestack.spokestack.webrtc.AutomaticGainControl");
+        stages.add("io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor");
+        stages.add("io.spokestack.spokestack.webrtc.VoiceActivityDetector");
+        stages.add("io.spokestack.spokestack.webrtc.VoiceActivityTrigger");
+        stages.add("io.spokestack.spokestack.ActivationTimeout");
+        stages.add("io.spokestack.spokestack.google.GoogleSpeechRecognizer");
+
         return builder
-              .setInputClass(
-                    "io.spokestack.spokestack.android.MicrophoneInput")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AutomaticGainControl")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.VoiceActivityDetector")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.VoiceActivityTrigger")
-              .addStageClass("io.spokestack.spokestack.ActivationTimeout")
-              .addStageClass(
-                    "io.spokestack.spokestack.google.GoogleSpeechRecognizer");
+              .setInputClass("io.spokestack.spokestack.android.MicrophoneInput")
+              .setStageClasses(stages);
     }
 }

--- a/src/main/java/io/spokestack/spokestack/profile/VADTriggerSpokestackASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/VADTriggerSpokestackASR.java
@@ -3,6 +3,9 @@ package io.spokestack.spokestack.profile;
 import io.spokestack.spokestack.PipelineProfile;
 import io.spokestack.spokestack.SpeechPipeline;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * A speech pipeline profile that uses voice activity detection to activate
  * Spokestack's cloud-based ASR.
@@ -31,19 +34,16 @@ import io.spokestack.spokestack.SpeechPipeline;
 public class VADTriggerSpokestackASR implements PipelineProfile {
     @Override
     public SpeechPipeline.Builder apply(SpeechPipeline.Builder builder) {
+        List<String> stages = new ArrayList<>();
+        stages.add("io.spokestack.spokestack.webrtc.AutomaticGainControl");
+        stages.add("io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor");
+        stages.add("io.spokestack.spokestack.webrtc.VoiceActivityDetector");
+        stages.add("io.spokestack.spokestack.webrtc.VoiceActivityTrigger");
+        stages.add("io.spokestack.spokestack.ActivationTimeout");
+        stages.add("io.spokestack.spokestack.asr.SpokestackCloudRecognizer");
+
         return builder
-              .setInputClass(
-                    "io.spokestack.spokestack.android.MicrophoneInput")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AutomaticGainControl")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.VoiceActivityDetector")
-              .addStageClass(
-                    "io.spokestack.spokestack.webrtc.VoiceActivityTrigger")
-              .addStageClass("io.spokestack.spokestack.ActivationTimeout")
-              .addStageClass(
-                    "io.spokestack.spokestack.asr.SpokestackCloudRecognizer");
+              .setInputClass("io.spokestack.spokestack.android.MicrophoneInput")
+              .setStageClasses(stages);
     }
 }

--- a/src/main/java/io/spokestack/spokestack/tts/TTSManager.java
+++ b/src/main/java/io/spokestack/spokestack/tts/TTSManager.java
@@ -138,11 +138,10 @@ public final class TTSManager implements AutoCloseable {
 
     /**
      * Sets the android context for the TTS Subsystem. Some components may
-     * require an application context instead of an activity context;
-     * see individual component documentation for details.
+     * require an application context instead of an activity context; see
+     * individual component documentation for details.
      *
      * @param androidContext the android context for the TTS subsystem.
-     *
      * @see io.spokestack.spokestack.tts.SpokestackTTSOutput
      */
     public void setAndroidContext(Context androidContext) {
@@ -162,29 +161,30 @@ public final class TTSManager implements AutoCloseable {
 
     /**
      * Dynamically constructs TTS component classes, allocating any resources
-     * they control.
+     * they control. It is only necessary to explicitly call this if the TTS
+     * subsystem's resources have been freed via {@link #release()}} or {@link
+     * #close()}.
      *
      * @throws Exception If there is an error constructing TTS components.
      */
     public void prepare() throws Exception {
-        if (this.ttsService != null) {
-            throw new IllegalStateException("already prepared");
-        }
-
-        this.ttsService =
-              createComponent(this.ttsServiceClass, TTSService.class);
-        if (this.outputClass != null && this.output == null) {
-            this.output = createComponent(this.outputClass, SpeechOutput.class);
-            this.output.setAndroidContext(appContext);
-            this.ttsService.addListener(this.output);
-            if (this.lifecycle != null) {
-                this.registerLifecycle(this.lifecycle);
+        if (this.ttsService == null) {
+            this.ttsService =
+                  createComponent(this.ttsServiceClass, TTSService.class);
+            if (this.outputClass != null && this.output == null) {
+                this.output = createComponent(
+                      this.outputClass, SpeechOutput.class);
+                this.output.setAndroidContext(appContext);
+                this.ttsService.addListener(this.output);
+                if (this.lifecycle != null) {
+                    this.registerLifecycle(this.lifecycle);
+                }
             }
-        }
-        for (TTSListener listener : this.listeners) {
-            this.ttsService.addListener(listener);
-            if (this.output != null) {
-                this.output.addListener(listener);
+            for (TTSListener listener : this.listeners) {
+                this.ttsService.addListener(listener);
+                if (this.output != null) {
+                    this.output.addListener(listener);
+                }
             }
         }
     }
@@ -202,6 +202,11 @@ public final class TTSManager implements AutoCloseable {
      * Stops activity in the TTS subsystem and releases any resources held by
      * its components. No internally queued audio will be played after this
      * method is called, and the queue will be cleared.
+     *
+     * <p>
+     * Once released, an explicit call to {@link #prepare()} is required to
+     * reallocate a manager's resources.
+     * </p>
      */
     public void release() {
         if (this.output != null) {
@@ -244,8 +249,11 @@ public final class TTSManager implements AutoCloseable {
 
         /**
          * Initializes a new builder with no default configuration.
+         *
+         * @see TTSManager
          */
-        public Builder() { }
+        public Builder() {
+        }
 
         /**
          * Sets the class name of the external TTS service component.
@@ -294,8 +302,8 @@ public final class TTSManager implements AutoCloseable {
 
         /**
          * Sets the Android context for the pipeline. Some components may
-         * require an Application context instead of an Activity context;
-         * see individual component documentation for details.
+         * require an Application context instead of an Activity context; see
+         * individual component documentation for details.
          *
          * @param androidContext The Android context for the pipeline.
          * @return this

--- a/src/main/resources/checkstyle.xml
+++ b/src/main/resources/checkstyle.xml
@@ -118,7 +118,10 @@
 
         <!-- Checks for Size Violations.                    -->
         <!-- See http://checkstyle.sf.net/config_sizes.html -->
-        <module name="LineLength"/>
+        <module name="LineLength">
+            <!-- ignore javadoc line length -->
+            <property name="ignorePattern" value="^\s+\* .*$"/>
+        </module>
         <module name="MethodLength"/>
         <module name="ParameterNumber"/>
 

--- a/src/test/java/io/spokestack/spokestack/SpokestackTest.java
+++ b/src/test/java/io/spokestack/spokestack/SpokestackTest.java
@@ -1,0 +1,266 @@
+package io.spokestack.spokestack;
+
+import android.content.Context;
+import android.os.SystemClock;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.LifecycleRegistry;
+import io.spokestack.spokestack.nlu.NLUContext;
+import io.spokestack.spokestack.nlu.NLUResult;
+import io.spokestack.spokestack.nlu.tensorflow.NLUTestUtils;
+import io.spokestack.spokestack.nlu.tensorflow.TensorflowNLU;
+import io.spokestack.spokestack.tts.SynthesisRequest;
+import io.spokestack.spokestack.tts.TTSEvent;
+import io.spokestack.spokestack.tts.TTSManager;
+import io.spokestack.spokestack.tts.TTSTestUtils;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.ArrayList;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({SystemClock.class})
+public class SpokestackTest {
+
+    @Test
+    public void testBuild() throws Exception {
+        // missing all required config
+        assertThrows(IllegalArgumentException.class,
+              () -> new Spokestack.Builder().build());
+
+        Spokestack.Builder builder = new Spokestack.Builder();
+
+        // missing lifecycle
+        assertThrows(IllegalArgumentException.class,
+              () -> {
+                  builder
+                        .setAndroidContext(mock(Context.class))
+                        .build();
+              });
+
+        // TTS playback disabled
+        // avoid creating a real websocket by also faking the service class
+        Spokestack.Builder noOutputBuilder = new Spokestack.Builder()
+              .disableAsr()
+              .disableNlu()
+              .disableTtsPlayback();
+        noOutputBuilder.getTtsBuilder().setTTSServiceClass(
+              "io.spokestack.spokestack.tts.TTSTestUtils$Service");
+
+        Spokestack noOutput = noOutputBuilder.build();
+        assertNull(noOutput.getTts().getOutput());
+
+        // everything disabled
+        // note that it's unnecessary to call both disableWakeword() and
+        // disableAsr() or disableTts() and disableTtsPlayback() for normal
+        // usage
+        Spokestack spokestack = builder
+              .disableWakeword()
+              .disableAsr()
+              .disableNlu()
+              .disableTts()
+              .disableTtsPlayback()
+              .setProperty("test", "test")
+              .build();
+
+        // no subsystems exist to handle these calls
+        assertThrows(NullPointerException.class, spokestack::start);
+        assertThrows(NullPointerException.class,
+              () -> spokestack.classify("test"));
+        assertThrows(NullPointerException.class, spokestack::stopPlayback);
+
+        // closing with no active subsystems is fine
+        assertDoesNotThrow(spokestack::close);
+    }
+
+    @Test
+    public void testSpeechPipeline() throws Exception {
+        mockStatic(SystemClock.class);
+        TestAdapter listener = new TestAdapter();
+
+        Spokestack.Builder builder = new Spokestack.Builder()
+              .setConfig(testConfig())
+              .disableWakeword()
+              .disableNlu()
+              .disableTts()
+              .addListener(listener);
+
+        builder.getPipelineBuilder().setStageClasses(new ArrayList<>());
+        Spokestack spokestack = builder.build();
+
+        listener.setSpokestack(spokestack);
+
+        // activations work through both the retrieved pipeline and the wrapper
+        spokestack.getSpeechPipeline().activate();
+        SpeechContext.Event event =
+              listener.speechEvents.poll(1, TimeUnit.SECONDS);
+        assertEquals(SpeechContext.Event.ACTIVATE, event);
+
+        spokestack.deactivate();
+        event = listener.speechEvents.poll(1, TimeUnit.SECONDS);
+        assertEquals(SpeechContext.Event.DEACTIVATE, event);
+
+        // other convenience methods
+        spokestack.activate();
+        event = listener.speechEvents.poll(1, TimeUnit.SECONDS);
+        assertEquals(SpeechContext.Event.ACTIVATE, event);
+        spokestack.start();
+        assertTrue(spokestack.getSpeechPipeline().isRunning());
+        spokestack.stop();
+        assertFalse(spokestack.getSpeechPipeline().isRunning());
+    }
+
+    @Test
+    public void testNlu() throws Exception {
+        mockStatic(SystemClock.class);
+        TestAdapter listener = new TestAdapter();
+
+        // inject fake builders into wrapper's builder
+        SpeechPipeline.Builder pipelineBuilder = new SpeechPipeline.Builder();
+
+        NLUTestUtils.TestEnv nluEnv = new NLUTestUtils.TestEnv();
+        TensorflowNLU.Builder nluBuilder = nluEnv.nluBuilder;
+
+        TTSManager.Builder ttsBuilder = new TTSManager.Builder();
+
+        Spokestack spokestack = new Spokestack
+              .Builder(pipelineBuilder, nluBuilder, ttsBuilder)
+              .disableWakeword()
+              .disableTts()
+              .addListener(listener)
+              .build();
+
+        listener.setSpokestack(spokestack);
+
+        NLUResult result = spokestack.classify("test").get();
+        NLUResult lastResult = listener.nluResults.poll(1, TimeUnit.SECONDS);
+        assertNotNull(lastResult);
+        assertEquals(result.getIntent(), lastResult.getIntent());
+
+        NLUContext fakeContext = new NLUContext(testConfig());
+        result = spokestack.getNlu().classify("test",fakeContext).get();
+        assertEquals(result.getIntent(), lastResult.getIntent());
+
+        // classification is called automatically on ASR results
+        assertTrue(listener.nluResults.isEmpty());
+        SpeechContext context = spokestack.getSpeechPipeline().getContext();
+        context.setTranscript("test");
+        context.dispatch(SpeechContext.Event.RECOGNIZE);
+        lastResult = listener.nluResults.poll(1, TimeUnit.SECONDS);
+        assertNotNull(lastResult);
+        assertEquals(result.getIntent(), lastResult.getIntent());
+    }
+
+    @Test
+    public void testTts() throws Exception {
+        mockStatic(SystemClock.class);
+        TestAdapter listener = new TestAdapter();
+
+        // inject fake builders into wrapper's builder
+        // speech pipeline
+        SpeechPipeline.Builder pipelineBuilder = new SpeechPipeline.Builder();
+
+        // NLU
+        NLUTestUtils.TestEnv nluEnv = new NLUTestUtils.TestEnv();
+        TensorflowNLU.Builder nluBuilder = nluEnv.nluBuilder;
+
+        // TTS
+        Context context = mock(Context.class);
+        LifecycleRegistry lifecycleRegistry =
+              new LifecycleRegistry(mock(LifecycleOwner.class));
+
+        TTSManager.Builder ttsBuilder = new TTSManager.Builder()
+              .setTTSServiceClass(
+                    "io.spokestack.spokestack.tts.TTSTestUtils$Service")
+              .setOutputClass(
+                    "io.spokestack.spokestack.tts.TTSTestUtils$Output")
+              .setProperty("spokestack-id", "default");
+
+        Spokestack spokestack = new Spokestack
+              .Builder(pipelineBuilder, nluBuilder, ttsBuilder)
+              .disableWakeword()
+              .setAndroidContext(context)
+              .setLifecycle(lifecycleRegistry)
+              .addListener(listener)
+              .build();
+
+        listener.setSpokestack(spokestack);
+        TTSManager tts = spokestack.getTts();
+
+        LinkedBlockingQueue<String> events = new LinkedBlockingQueue<>();
+        ((TTSTestUtils.Output) tts.getOutput()).setEventQueue(events);
+
+        spokestack.classify("test").get();
+        NLUResult lastResult = listener.nluResults.poll(1, TimeUnit.SECONDS);
+        assertNotNull(lastResult);
+
+        TTSEvent event = listener.ttsEvents.poll(1, TimeUnit.SECONDS);
+        assertNotNull(event);
+        assertEquals(TTSEvent.Type.AUDIO_AVAILABLE, event.type);
+        String outputEvent = events.poll(1, TimeUnit.SECONDS);
+        assertEquals("audioReceived", outputEvent);
+
+        // other convenience methods
+        spokestack.releaseTts();
+        assertNull(tts.getTtsService());
+        spokestack.prepareTts();
+        assertNotNull(tts.getTtsService());
+        spokestack.stopPlayback();
+        outputEvent = events.poll(1, TimeUnit.SECONDS);
+        assertEquals("stop", outputEvent);
+
+        // close with a valid speech pipeline and TTS
+        assertDoesNotThrow(spokestack::close);
+    }
+
+    private SpeechConfig testConfig() {
+        SpeechConfig config = NLUTestUtils.testConfig();
+        config.put("sample-rate", 16000);
+        config.put("frame-width", 20);
+        config.put("buffer-width", 300);
+        return config;
+    }
+
+    static class TestAdapter extends SpokestackAdapter {
+        SpeechContext speechContext;
+        Spokestack spokestack;
+        LinkedBlockingQueue<NLUResult> nluResults = new LinkedBlockingQueue<>();
+        LinkedBlockingQueue<TTSEvent> ttsEvents = new LinkedBlockingQueue<>();
+        LinkedBlockingQueue<SpeechContext.Event> speechEvents =
+              new LinkedBlockingQueue<>();
+
+        public void setSpokestack(Spokestack spokestack) {
+            this.spokestack = spokestack;
+        }
+
+        @Override
+        public void onEvent(@NotNull SpeechContext.Event event,
+                            @NotNull SpeechContext context) {
+            this.speechEvents.add(event);
+            this.speechContext = context;
+        }
+
+        @Override
+        public void eventReceived(@NotNull TTSEvent event) {
+            this.ttsEvents.add(event);
+        }
+
+        @Override
+        public void call(@NotNull NLUResult result) {
+            this.nluResults.add(result);
+            if (this.spokestack != null) {
+                SynthesisRequest request =
+                      new SynthesisRequest.Builder(result.getIntent()).build();
+                this.spokestack.synthesize(request);
+            }
+        }
+    }
+}

--- a/src/test/java/io/spokestack/spokestack/SpokestackTest.java
+++ b/src/test/java/io/spokestack/spokestack/SpokestackTest.java
@@ -49,9 +49,9 @@ public class SpokestackTest {
         // TTS playback disabled
         // avoid creating a real websocket by also faking the service class
         Spokestack.Builder noOutputBuilder = new Spokestack.Builder()
-              .disableAsr()
-              .disableNlu()
-              .disableTtsPlayback();
+              .withoutSpeechPipeline()
+              .withoutNlu()
+              .withoutAutoPlayback();
         noOutputBuilder.getTtsBuilder().setTTSServiceClass(
               "io.spokestack.spokestack.tts.TTSTestUtils$Service");
 
@@ -63,11 +63,11 @@ public class SpokestackTest {
         // disableAsr() or disableTts() and disableTtsPlayback() for normal
         // usage
         Spokestack spokestack = builder
-              .disableWakeword()
-              .disableAsr()
-              .disableNlu()
-              .disableTts()
-              .disableTtsPlayback()
+              .withoutWakeword()
+              .withoutSpeechPipeline()
+              .withoutNlu()
+              .withoutTts()
+              .withoutAutoPlayback()
               .setProperty("test", "test")
               .build();
 
@@ -88,9 +88,9 @@ public class SpokestackTest {
 
         Spokestack.Builder builder = new Spokestack.Builder()
               .setConfig(testConfig())
-              .disableWakeword()
-              .disableNlu()
-              .disableTts()
+              .withoutWakeword()
+              .withoutNlu()
+              .withoutTts()
               .addListener(listener);
 
         builder.getPipelineBuilder().setStageClasses(new ArrayList<>());
@@ -152,7 +152,7 @@ public class SpokestackTest {
         TestAdapter listener = new TestAdapter();
 
         Spokestack spokestack = mockedNluBuilder()
-              .disableAutoClassification()
+              .withoutAutoClassification()
               .addListener(listener)
               .build();
 
@@ -203,8 +203,8 @@ public class SpokestackTest {
               nluBuilder,
               new TTSManager.Builder()
         )
-              .disableWakeword()
-              .disableTts();
+              .withoutWakeword()
+              .withoutTts();
     }
 
     @Test
@@ -234,7 +234,7 @@ public class SpokestackTest {
 
         Spokestack spokestack = new Spokestack
               .Builder(pipelineBuilder, nluBuilder, ttsBuilder)
-              .disableWakeword()
+              .withoutWakeword()
               .withAndroidContext(context)
               .withLifecycle(lifecycleRegistry)
               .addListener(listener)

--- a/src/test/java/io/spokestack/spokestack/nlu/SlotTest.java
+++ b/src/test/java/io/spokestack/spokestack/nlu/SlotTest.java
@@ -40,7 +40,7 @@ class SlotTest {
     @Test
     void testToString() {
         Slot one = new Slot("test", "1", 1);
-        String expected = "Slot{name=\"test\", rawValue=1, value=1}";
+        String expected = "Slot{name=\"test\", type=null, rawValue=1, value=1}";
         assertEquals(expected, one.toString());
     }
 }

--- a/src/test/java/io/spokestack/spokestack/nlu/tensorflow/NLUTestUtils.java
+++ b/src/test/java/io/spokestack/spokestack/nlu/tensorflow/NLUTestUtils.java
@@ -1,0 +1,137 @@
+package io.spokestack.spokestack.nlu.tensorflow;
+
+import android.os.SystemClock;
+import com.google.gson.Gson;
+import com.google.gson.stream.JsonReader;
+import io.spokestack.spokestack.SpeechConfig;
+import io.spokestack.spokestack.nlu.NLUResult;
+import io.spokestack.spokestack.tensorflow.TensorflowModel;
+
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Future;
+
+import static org.mockito.Mockito.*;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+
+public class NLUTestUtils {
+
+    public static SpeechConfig testConfig() {
+        return new SpeechConfig()
+              .put("nlu-model-path", "model-path")
+              .put("nlu-metadata-path", "src/test/resources/nlu.json")
+              .put("wordpiece-vocab-path", "src/test/resources/vocab.txt");
+    }
+
+    public static class TestModel extends TensorflowModel {
+        public TestModel(TensorflowModel.Loader loader) {
+            super(loader);
+        }
+
+        public void run() {
+            this.inputs(0).rewind();
+            this.outputs(0).rewind();
+            this.outputs(1).rewind();
+        }
+
+        public final void setOutputs(float[] intentsOut, float[] tagsOut) {
+            this.outputs(0).rewind();
+            for (float f : intentsOut) {
+                this.outputs(0).putFloat(f);
+            }
+            this.outputs(1).rewind();
+            for (float o : tagsOut) {
+                this.outputs(1).putFloat(o);
+            }
+        }
+    }
+
+    public static class TestEnv implements TextEncoder {
+        public final TensorflowModel.Loader loader;
+        public final TestModel testModel;
+        public final TensorflowNLU.Builder nluBuilder;
+        public final Metadata metadata;
+
+        public TensorflowNLU nlu;
+
+        public TestEnv() throws Exception {
+            this(testConfig());
+        }
+
+        public TestEnv(SpeechConfig config) throws Exception {
+            // fetch configuration parameters
+            String metadataPath = config.getString("nlu-metadata-path");
+            this.metadata = loadMetadata(metadataPath);
+
+            // create/mock tensorflow-lite models
+            int maxTokens = 100;
+            this.loader = spy(TensorflowModel.Loader.class);
+            this.testModel = mock(TestModel.class);
+
+            doReturn(ByteBuffer
+                  .allocateDirect(maxTokens * metadata.getIntents().length * 4)
+                  .order(ByteOrder.nativeOrder()))
+                  .when(this.testModel).inputs(0);
+            doReturn(ByteBuffer
+                  .allocateDirect(metadata.getIntents().length * 4)
+                  .order(ByteOrder.nativeOrder()))
+                  .when(this.testModel).outputs(0);
+            doReturn(ByteBuffer
+                  .allocateDirect(maxTokens * metadata.getTags().length * 4)
+                  .order(ByteOrder.nativeOrder()))
+                  .when(this.testModel).outputs(1);
+            doReturn(4).when(this.testModel).getInputSize();
+            doCallRealMethod().when(this.testModel).run();
+            doReturn(this.testModel)
+                  .when(this.loader).load();
+
+            this.nluBuilder =
+                  new TensorflowNLU.Builder()
+                        .setConfig(config)
+                        .setModelLoader(this.loader)
+                        .setTextEncoder(this);
+        }
+
+        private Metadata loadMetadata(String metadataPath)
+              throws FileNotFoundException {
+            FileReader fileReader = new FileReader(metadataPath);
+            Gson gson = new Gson();
+            JsonReader reader = new JsonReader(fileReader);
+            return gson.fromJson(reader, Metadata.class);
+        }
+
+        public Future<NLUResult> classify(String utterance) {
+            if (this.nlu == null) {
+                this.nlu = this.nluBuilder.build();
+            }
+            return this.nlu.classify(utterance);
+        }
+
+        @Override
+        public int encodeSingle(String token) {
+            return 1;
+        }
+
+        @Override
+        public EncodedTokens encode(String text) {
+            if (text.equals("error")) {
+                throw new IllegalStateException("forced test error");
+            }
+            String[] split = text.split(" ");
+            EncodedTokens encoded = new EncodedTokens(split);
+            List<Integer> ids = new ArrayList<>();
+            List<Integer> originalIndices = new ArrayList<>();
+            for (int i = 0; i < split.length; i++) {
+                ids.add(0);
+                originalIndices.add(i);
+            }
+            encoded.addTokenIds(ids);
+            encoded.setOriginalIndices(originalIndices);
+            return encoded;
+        }
+    }
+}

--- a/src/test/java/io/spokestack/spokestack/nlu/tensorflow/TensorflowNLUTest.java
+++ b/src/test/java/io/spokestack/spokestack/nlu/tensorflow/TensorflowNLUTest.java
@@ -1,12 +1,9 @@
 package io.spokestack.spokestack.nlu.tensorflow;
 
 import android.os.SystemClock;
-import com.google.gson.Gson;
-import com.google.gson.stream.JsonReader;
 import io.spokestack.spokestack.SpeechConfig;
 import io.spokestack.spokestack.nlu.NLUResult;
 import io.spokestack.spokestack.nlu.Slot;
-import io.spokestack.spokestack.tensorflow.TensorflowModel;
 import io.spokestack.spokestack.util.EventTracer;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
@@ -15,20 +12,14 @@ import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static io.spokestack.spokestack.nlu.tensorflow.NLUTestUtils.TestEnv;
+import static io.spokestack.spokestack.nlu.tensorflow.NLUTestUtils.testConfig;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
@@ -160,117 +151,6 @@ public class TensorflowNLUTest {
     private void setTag(float[] tagResult, int numTags,
                         int tokenIndex, int tagIndex) {
         tagResult[tokenIndex * numTags + tagIndex] = 10;
-    }
-
-    public SpeechConfig testConfig() {
-        return new SpeechConfig()
-              .put("nlu-model-path", "model-path")
-              .put("nlu-metadata-path", "src/test/resources/nlu.json")
-              .put("wordpiece-vocab-path", "src/test/resources/vocab.txt");
-    }
-
-    public static class TestModel extends TensorflowModel {
-        public TestModel(TensorflowModel.Loader loader) {
-            super(loader);
-        }
-
-        public void run() {
-            this.inputs(0).rewind();
-            this.outputs(0).rewind();
-            this.outputs(1).rewind();
-        }
-
-        public final void setOutputs(float[] intentsOut, float[] tagsOut) {
-            this.outputs(0).rewind();
-            for (float f : intentsOut) {
-                this.outputs(0).putFloat(f);
-            }
-            this.outputs(1).rewind();
-            for (float o : tagsOut) {
-                this.outputs(1).putFloat(o);
-            }
-        }
-    }
-
-    public static class TestEnv implements TextEncoder {
-        public final TensorflowModel.Loader loader;
-        public final TensorflowNLUTest.TestModel testModel;
-        public final TensorflowNLU.Builder nluBuilder;
-        public final Metadata metadata;
-
-        public TensorflowNLU nlu;
-
-        public TestEnv(SpeechConfig config) throws Exception {
-            // fetch configuration parameters
-            String metadataPath = config.getString("nlu-metadata-path");
-            this.metadata = loadMetadata(metadataPath);
-
-            // create/mock tensorflow-lite models
-            int maxTokens = 100;
-            this.loader = spy(TensorflowModel.Loader.class);
-            this.testModel = mock(TensorflowNLUTest.TestModel.class);
-
-            doReturn(ByteBuffer
-                  .allocateDirect(maxTokens * metadata.getIntents().length * 4)
-                  .order(ByteOrder.nativeOrder()))
-                  .when(this.testModel).inputs(0);
-            doReturn(ByteBuffer
-                  .allocateDirect(metadata.getIntents().length * 4)
-                  .order(ByteOrder.nativeOrder()))
-                  .when(this.testModel).outputs(0);
-            doReturn(ByteBuffer
-                  .allocateDirect(maxTokens * metadata.getTags().length * 4)
-                  .order(ByteOrder.nativeOrder()))
-                  .when(this.testModel).outputs(1);
-            doReturn(4).when(this.testModel).getInputSize();
-            doCallRealMethod().when(this.testModel).run();
-            doReturn(this.testModel)
-                  .when(this.loader).load();
-
-            this.nluBuilder =
-                  new TensorflowNLU.Builder()
-                        .setConfig(config)
-                        .setModelLoader(this.loader)
-                        .setTextEncoder(this);
-        }
-
-        private Metadata loadMetadata(String metadataPath)
-              throws FileNotFoundException {
-            FileReader fileReader = new FileReader(metadataPath);
-            Gson gson = new Gson();
-            JsonReader reader = new JsonReader(fileReader);
-            return gson.fromJson(reader, Metadata.class);
-        }
-
-        public Future<NLUResult> classify(String utterance) {
-            if (this.nlu == null) {
-                this.nlu = this.nluBuilder.build();
-            }
-            return this.nlu.classify(utterance);
-        }
-
-        @Override
-        public int encodeSingle(String token) {
-            return 1;
-        }
-
-        @Override
-        public EncodedTokens encode(String text) {
-            if (text.equals("error")) {
-                throw new IllegalStateException("forced test error");
-            }
-            String[] split = text.split(" ");
-            EncodedTokens encoded = new EncodedTokens(split);
-            List<Integer> ids = new ArrayList<>();
-            List<Integer> originalIndices = new ArrayList<>();
-            for (int i = 0; i < split.length; i++) {
-                ids.add(0);
-                originalIndices.add(i);
-            }
-            encoded.addTokenIds(ids);
-            encoded.setOriginalIndices(originalIndices);
-            return encoded;
-        }
     }
 
     static class ControllableFactory implements ThreadFactory {

--- a/src/test/java/io/spokestack/spokestack/tts/SpokestackTTSOutputTest.java
+++ b/src/test/java/io/spokestack/spokestack/tts/SpokestackTTSOutputTest.java
@@ -11,8 +11,13 @@ import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.LifecycleRegistry;
 import com.google.android.exoplayer2.ExoPlaybackException;
 import com.google.android.exoplayer2.ExoPlayer;
+import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Player;
+import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.source.MediaSource;
+import com.google.android.exoplayer2.source.SinglePeriodTimeline;
+import com.google.android.exoplayer2.source.TrackGroupArray;
+import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -192,16 +197,20 @@ public class SpokestackTTSOutputTest {
 
         // these methods are implemented solely to maintain compatibility with
         // older Android APIs; calling them should do nothing
-        ttsOutput.onTimelineChanged(null, 0);
-        ttsOutput.onTimelineChanged(null, null, 0);
-        ttsOutput.onTracksChanged(null, null);
+        Timeline timeline = new SinglePeriodTimeline(0, false, false, false);
+        ttsOutput.onTimelineChanged(timeline, 0);
+        ttsOutput.onTimelineChanged(timeline, null, 0);
+        TrackGroupArray groupArray = new TrackGroupArray();
+        TrackSelectionArray selectionArray = new TrackSelectionArray();
+        ttsOutput.onTracksChanged(groupArray, selectionArray);
         ttsOutput.onLoadingChanged(true);
         ttsOutput.onPlaybackSuppressionReasonChanged(0);
         ttsOutput.onIsPlayingChanged(false);
         ttsOutput.onRepeatModeChanged(0);
         ttsOutput.onShuffleModeEnabledChanged(false);
         ttsOutput.onPositionDiscontinuity(-10);
-        ttsOutput.onPlaybackParametersChanged(null);
+        PlaybackParameters params = new PlaybackParameters(1.0f);
+        ttsOutput.onPlaybackParametersChanged(params);
         ttsOutput.onSeekProcessed();
     }
 

--- a/src/test/java/io/spokestack/spokestack/tts/TTSManagerTest.java
+++ b/src/test/java/io/spokestack/spokestack/tts/TTSManagerTest.java
@@ -4,13 +4,10 @@ package io.spokestack.spokestack.tts;
 import android.content.Context;
 import android.net.Uri;
 import androidx.annotation.NonNull;
-import androidx.lifecycle.DefaultLifecycleObserver;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.LifecycleRegistry;
 import io.spokestack.spokestack.SpeechConfig;
-import io.spokestack.spokestack.SpeechOutput;
-import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,15 +25,13 @@ import static org.mockito.Mockito.mock;
 public class TTSManagerTest implements TTSListener {
 
     @Mock
-    private Context context = mock(Context.class);
+    private final Context context = mock(Context.class);
 
     private TTSEvent lastEvent;
-    private static LinkedBlockingQueue<String> events;
 
     @Before
     public void before() {
         lastEvent = null;
-        events = new LinkedBlockingQueue<>();
     }
 
     @Test
@@ -62,8 +57,8 @@ public class TTSManagerTest implements TTSListener {
               new LifecycleRegistry(mock(LifecycleOwner.class));
 
         TTSManager manager = new TTSManager.Builder()
-              .setTTSServiceClass("io.spokestack.spokestack.tts.TTSManagerTest$Input")
-              .setOutputClass("io.spokestack.spokestack.tts.TTSManagerTest$Output")
+              .setTTSServiceClass("io.spokestack.spokestack.tts.TTSTestUtils$Service")
+              .setOutputClass("io.spokestack.spokestack.tts.TTSTestUtils$Output")
               .setProperty("spokestack-id", "test")
               .setConfig(new SpeechConfig())
               .setAndroidContext(context)
@@ -71,7 +66,10 @@ public class TTSManagerTest implements TTSListener {
               .addTTSListener(this)
               .build();
 
-        assertThrows(IllegalStateException.class, manager::prepare);
+        LinkedBlockingQueue<String> events =
+              ((TTSTestUtils.Output) manager.getOutput()).getEvents();
+
+        manager.prepare();
         assertNotNull(manager.getTtsService());
         assertNotNull(manager.getOutput());
 
@@ -100,6 +98,7 @@ public class TTSManagerTest implements TTSListener {
         assertNotNull(manager.getOutput());
 
         lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+        events = ((TTSTestUtils.Output) manager.getOutput()).getEvents();
         event = events.poll(1, TimeUnit.SECONDS);
         assertEquals("onResume", event, "onResume not called");
 
@@ -112,7 +111,7 @@ public class TTSManagerTest implements TTSListener {
     @Test
     public void testStop() throws Exception {
         TTSManager manager = new TTSManager.Builder()
-              .setTTSServiceClass("io.spokestack.spokestack.tts.TTSManagerTest$Input")
+              .setTTSServiceClass("io.spokestack.spokestack.tts.TTSTestUtils$Service")
               .setProperty("spokestack-id", "test")
               .setConfig(new SpeechConfig())
               .setAndroidContext(context)
@@ -123,13 +122,16 @@ public class TTSManagerTest implements TTSListener {
         manager.stopPlayback();
 
         manager = new TTSManager.Builder()
-              .setTTSServiceClass("io.spokestack.spokestack.tts.TTSManagerTest$Input")
-              .setOutputClass("io.spokestack.spokestack.tts.TTSManagerTest$Output")
+              .setTTSServiceClass("io.spokestack.spokestack.tts.TTSTestUtils$Service")
+              .setOutputClass("io.spokestack.spokestack.tts.TTSTestUtils$Output")
               .setProperty("spokestack-id", "test")
               .setConfig(new SpeechConfig())
               .setAndroidContext(context)
               .addTTSListener(this)
               .build();
+
+        LinkedBlockingQueue<String> events =
+              ((TTSTestUtils.Output) manager.getOutput()).getEvents();
 
         manager.stopPlayback();
         assertEquals("stop", events.remove(), "stop not called on output");
@@ -138,61 +140,5 @@ public class TTSManagerTest implements TTSListener {
     @Override
     public void eventReceived(@NonNull TTSEvent event) {
         lastEvent = event;
-    }
-
-    public static class Input extends TTSService {
-
-        public Input(SpeechConfig config) {
-            String key = config.getString("spokestack-id", "default");
-            if (!key.equals("default")) {
-                fail("custom client ID should not be set by tests");
-            }
-        }
-
-        @Override
-        public void synthesize(SynthesisRequest request) {
-            TTSEvent synthesisComplete =
-                  new TTSEvent(TTSEvent.Type.AUDIO_AVAILABLE);
-            AudioResponse response = new AudioResponse(Uri.EMPTY);
-            synthesisComplete.setTtsResponse(response);
-            dispatch(synthesisComplete);
-        }
-
-        @Override
-        public void close() {
-        }
-    }
-
-    public static class Output extends SpeechOutput
-          implements DefaultLifecycleObserver {
-
-        @SuppressWarnings("unused")
-        public Output(SpeechConfig config) { }
-
-        @Override
-        public void onResume(@NotNull LifecycleOwner owner) {
-            // protect against multiple calls by the registry during tests
-            if (events.isEmpty()) {
-                events.add("onResume");
-            }
-        }
-
-        @Override
-        public void audioReceived(AudioResponse response) {
-            events.add("audioReceived");
-        }
-
-        @Override
-        public void stopPlayback() {
-            events.add("stop");
-        }
-
-        @Override
-        public void setAndroidContext(Context appContext) { }
-
-        @Override
-        public void close() {
-            throw new RuntimeException("can't close won't close");
-        }
     }
 }

--- a/src/test/java/io/spokestack/spokestack/tts/TTSTestUtils.java
+++ b/src/test/java/io/spokestack/spokestack/tts/TTSTestUtils.java
@@ -1,0 +1,85 @@
+package io.spokestack.spokestack.tts;
+
+import android.content.Context;
+import android.net.Uri;
+import androidx.lifecycle.DefaultLifecycleObserver;
+import androidx.lifecycle.LifecycleOwner;
+import io.spokestack.spokestack.SpeechConfig;
+import io.spokestack.spokestack.SpeechOutput;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TTSTestUtils {
+
+    public static class Service extends TTSService {
+
+        public Service(SpeechConfig config) {
+            String key = config.getString("spokestack-id", "default");
+            if (!key.equals("default")) {
+                fail("custom client ID should not be set by tests");
+            }
+        }
+
+        @Override
+        public void synthesize(SynthesisRequest request) {
+            TTSEvent synthesisComplete =
+                  new TTSEvent(TTSEvent.Type.AUDIO_AVAILABLE);
+            AudioResponse response = new AudioResponse(Uri.EMPTY);
+            synthesisComplete.setTtsResponse(response);
+            dispatch(synthesisComplete);
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    public static class Output extends SpeechOutput
+          implements DefaultLifecycleObserver {
+
+        LinkedBlockingQueue<String> events;
+
+        @SuppressWarnings("unused")
+        public Output(SpeechConfig config) {
+            this.events = new LinkedBlockingQueue<>();
+        }
+
+        public void setEventQueue(LinkedBlockingQueue<String> events) {
+            this.events = events;
+        }
+
+        public LinkedBlockingQueue<String> getEvents() {
+            return events;
+        }
+
+        @Override
+        public void onResume(@NotNull LifecycleOwner owner) {
+            // protect against multiple calls by the registry during tests
+            if (this.events.isEmpty()) {
+                this.events.add("onResume");
+            }
+        }
+
+        @Override
+        public void audioReceived(AudioResponse response) {
+            this.events.add("audioReceived");
+        }
+
+        @Override
+        public void stopPlayback() {
+            this.events.add("stop");
+        }
+
+        @Override
+        public void setAndroidContext(Context appContext) {
+        }
+
+        @Override
+        public void close() {
+            throw new RuntimeException("can't close won't close");
+        }
+    }
+}


### PR DESCRIPTION
This adds a `Spokestack` class that performs setup of all individual subsystems in a central place. It provides a default configuration but allows full client customizability via access to each of the subsystems' individual builders and the subsystems themselves after construction is complete. Individual subsystems can be disabled before building if unwanted.

It also consolidates listening for various Spokestack events into a `SpokestackAdapter` class (inspired by `java.awt.MouseAdapter`) so that clients can extend a single class and handle only events they care about.

Apart from setup convenience, the `Spokestack` wrapper also registers itself as a listener for all subsystems and handles tasks necessary for voice interaction like automatically classifying ASR results (the client will still need to listen for NLU events in order to provide a response).

The majority of the changes here are just test refactors to ease testing certain subsystems in more than one test class (and copious javadoc for the new wrapper). I've separated the changeset into individual commits with that in mind; the refactors are in the first commit, the additions in the second.