### PR TITLE
fix: don't send irrelevant playback events

### DIFF
--- a/src/main/java/io/spokestack/spokestack/tts/SpokestackTTSOutput.java
+++ b/src/main/java/io/spokestack/spokestack/tts/SpokestackTTSOutput.java
@@ -212,8 +212,12 @@ public class SpokestackTTSOutput extends SpeechOutput
     @Override
     public void onPlayerStateChanged(boolean playWhenReady, int playbackState) {
         if (playbackState == Player.STATE_ENDED) {
-            resetPlayerState();
-            dispatch(new TTSEvent(TTSEvent.Type.PLAYBACK_COMPLETE));
+            // check for content produced by the TTS system; the player can
+            // also receive state change events for audio from another source
+            if (this.playerState.hasContent) {
+                dispatch(new TTSEvent(TTSEvent.Type.PLAYBACK_COMPLETE));
+                resetPlayerState();
+            }
         }
     }
 

--- a/src/test/java/io/spokestack/spokestack/tts/SpokestackTTSOutputTest.java
+++ b/src/test/java/io/spokestack/spokestack/tts/SpokestackTTSOutputTest.java
@@ -150,6 +150,13 @@ public class SpokestackTTSOutputTest {
 
         ttsOutput.onPlayerStateChanged(false, Player.STATE_ENDED);
         assertFalse(ttsOutput.getPlayerState().hasContent);
+        // no playback_complete event if the player didn't have content from
+        // the TTS system
+        assertTrue(listener.events.isEmpty());
+
+        // now give it audio to play and check again
+        ttsOutput.audioReceived(new AudioResponse(Uri.EMPTY));
+        ttsOutput.onPlayerStateChanged(false, Player.STATE_ENDED);
         assertEquals(1, listener.events.size());
         assertEquals(TTSEvent.Type.PLAYBACK_COMPLETE,
               listener.events.get(0).type);


### PR DESCRIPTION
It appears that ExoPlayer can fire state change events for audio
from any source. During development, I noticed seemingly duplicate events
triggered by the Google Assistant deactivation sound. This change prevents
Spokestack PLAYBACK_COMPLETE events from being dispatched unless the
player was known to have received audio from Spokestack when the state
change event occurred.