### PR TITLE
Fix: don't send empty ASR transcripts

### DIFF
--- a/src/main/java/io/spokestack/spokestack/android/AndroidSpeechRecognizer.java
+++ b/src/main/java/io/spokestack/spokestack/android/AndroidSpeechRecognizer.java
@@ -222,10 +222,12 @@ public class AndroidSpeechRecognizer implements SpeechProcessor {
                   ? SpeechContext.Event.PARTIAL_RECOGNIZE
                   : SpeechContext.Event.RECOGNIZE;
             String transcript = extractTranscript(results);
-            float confidence = extractConfidence(results);
-            this.context.setTranscript(transcript);
-            this.context.setConfidence(confidence);
-            this.context.dispatch(event);
+            if (!transcript.equals("")) {
+                float confidence = extractConfidence(results);
+                this.context.setTranscript(transcript);
+                this.context.setConfidence(confidence);
+                this.context.dispatch(event);
+            }
         }
 
         private String extractTranscript(Bundle results) {

--- a/src/main/java/io/spokestack/spokestack/asr/SpokestackCloudRecognizer.java
+++ b/src/main/java/io/spokestack/spokestack/asr/SpokestackCloudRecognizer.java
@@ -144,12 +144,14 @@ public final class SpokestackCloudRecognizer implements SpeechProcessor {
         public void onSpeech(String transcript,
                              float confidence,
                              boolean isFinal) {
-            context.setTranscript(transcript);
-            context.setConfidence(confidence);
-            SpeechContext.Event event = (isFinal)
-                  ? SpeechContext.Event.RECOGNIZE
-                  : SpeechContext.Event.PARTIAL_RECOGNIZE;
-            context.dispatch(event);
+            if (!transcript.equals("")) {
+                context.setTranscript(transcript);
+                context.setConfidence(confidence);
+                SpeechContext.Event event = (isFinal)
+                      ? SpeechContext.Event.RECOGNIZE
+                      : SpeechContext.Event.PARTIAL_RECOGNIZE;
+                context.dispatch(event);
+            }
         }
 
         public void onError(Throwable e) {

--- a/src/main/java/io/spokestack/spokestack/microsoft/AzureSpeechRecognizer.java
+++ b/src/main/java/io/spokestack/spokestack/microsoft/AzureSpeechRecognizer.java
@@ -221,11 +221,13 @@ public class AzureSpeechRecognizer implements SpeechProcessor {
               SpeechRecognitionEventArgs recognitionArgs) {
             ResultReason reason = recognitionArgs.getResult().getReason();
             String transcript = recognitionArgs.getResult().getText();
-            if (reason == ResultReason.RecognizingSpeech) {
-                dispatchResult(transcript,
-                      SpeechContext.Event.PARTIAL_RECOGNIZE);
-            } else if (reason == ResultReason.RecognizedSpeech) {
-                dispatchResult(transcript, SpeechContext.Event.RECOGNIZE);
+            if (!transcript.equals("")) {
+                if (reason == ResultReason.RecognizingSpeech) {
+                    dispatchResult(transcript,
+                          SpeechContext.Event.PARTIAL_RECOGNIZE);
+                } else if (reason == ResultReason.RecognizedSpeech) {
+                    dispatchResult(transcript, SpeechContext.Event.RECOGNIZE);
+                }
             }
         }
 

--- a/src/test/java/io/spokestack/spokestack/android/AndroidSpeechRecognizerTest.java
+++ b/src/test/java/io/spokestack/spokestack/android/AndroidSpeechRecognizerTest.java
@@ -120,11 +120,19 @@ public class AndroidSpeechRecognizerTest {
         AndroidSpeechRecognizer.SpokestackListener asrListener =
               speechRecognizer.getListener();
 
+        // empty result
+        listener.clear();
+        Bundle results = MockRecognizer.speechResults("");
+        asrListener.onPartialResults(results);
+        assertFalse(listener.receivedPartial);
+        assertNull(listener.transcript);
+
         // partial result
         listener.clear();
-        Bundle results = MockRecognizer.speechResults("partial");
+        String transcript = "partial";
+        results = MockRecognizer.speechResults(transcript);
         asrListener.onPartialResults(results);
-        assertEquals(MockRecognizer.TRANSCRIPT, listener.transcript);
+        assertEquals(transcript, listener.transcript);
         assertTrue(listener.receivedPartial);
         assertNull(listener.error);
 

--- a/src/test/java/io/spokestack/spokestack/android/MockRecognizer.java
+++ b/src/test/java/io/spokestack/spokestack/android/MockRecognizer.java
@@ -6,7 +6,7 @@ import android.speech.RecognitionListener;
 import android.speech.SpeechRecognizer;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -48,7 +48,7 @@ public class MockRecognizer {
     public void startListening(Intent recognitionIntent) {
         Bundle results = mock(Bundle.class);
         ArrayList<String> nBest =
-              new ArrayList<>( Arrays.asList(TRANSCRIPT, "testy"));
+              new ArrayList<>(Collections.singletonList(TRANSCRIPT));
         when(results
               .getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION))
               .thenReturn(nBest);
@@ -78,7 +78,7 @@ public class MockRecognizer {
     public static Bundle speechResults(String transcript, Float confidence) {
         Bundle results = mock(Bundle.class);
         ArrayList<String> nBest =
-              new ArrayList<>( Arrays.asList(TRANSCRIPT, transcript));
+              new ArrayList<>(Collections.singletonList(transcript));
         when(results
               .getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION))
               .thenReturn(nBest);

--- a/src/test/java/io/spokestack/spokestack/asr/SpokestackCloudRecognizerTest.java
+++ b/src/test/java/io/spokestack/spokestack/asr/SpokestackCloudRecognizerTest.java
@@ -13,6 +13,7 @@ import java.util.LinkedList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.*;
 
 public class SpokestackCloudRecognizerTest implements OnSpeechEventListener {
@@ -111,6 +112,10 @@ public class SpokestackCloudRecognizerTest implements OnSpeechEventListener {
         assertEquals("test two", context.getTranscript());
         assertEquals(0.9f, context.getConfidence(), 1e-5);
         assertEquals(SpeechContext.Event.RECOGNIZE, this.event);
+
+        this.event = null;
+        listener.onSpeech("", 0.9f, true);
+        assertNull(this.event);
     }
 
     @Test


### PR DESCRIPTION
This change makes other speech recognizers match the behavior
of GoogleSpeechRecognizer, which filters out empty strings
before sending partial or full recognition results.