### PR TITLE
Fix: force pipeline stages to reset on deactivate

### DIFF
--- a/src/main/java/io/spokestack/spokestack/SpeechPipeline.java
+++ b/src/main/java/io/spokestack/spokestack/SpeechPipeline.java
@@ -130,7 +130,14 @@ public final class SpeechPipeline implements AutoCloseable {
 
     /** manually deactivate the speech pipeline. */
     public void deactivate() {
-        this.context.setActive(false);
+        this.context.reset();
+        for (SpeechProcessor stage : this.stages) {
+            try {
+                stage.reset();
+            } catch (Exception e) {
+                raiseError(e);
+            }
+        }
     }
 
     /**

--- a/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
+++ b/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
@@ -212,13 +212,20 @@ public class SpeechPipelineTest implements OnSpeechEventListener {
 
         // still no event, and the external activation isn't overridden by the
         // stage, which would normally deactivate on the second frame
-        pipeline.getContext().setActive(true);
+        pipeline.activate();
         transact(true);
         assertTrue(this.events.isEmpty());
         assertTrue(pipeline.getContext().isActive());
 
-        // turn off external management and get the expected activations/events
-        pipeline.getContext().setManaged(false);
+        // ensure that manual deactivation resets stages
+        assertFalse(Stage.reset);
+        pipeline.deactivate();
+        assertTrue(Stage.reset);
+        assertFalse(pipeline.getContext().isActive());
+        assertFalse(pipeline.getContext().isManaged());
+
+        // now that external management is off,
+        // we get the expected activations/events
         transact(false);
         assertEquals(SpeechContext.Event.ACTIVATE, this.events.get(0));
         assertTrue(pipeline.getContext().isActive());
@@ -291,12 +298,14 @@ public class SpeechPipelineTest implements OnSpeechEventListener {
 
     public static class Stage implements SpeechProcessor {
         public static boolean open;
+        public static boolean reset = false;
 
         public Stage(SpeechConfig config) {
             open = true;
         }
 
         public void reset() {
+            reset = true;
             close();
         }
 


### PR DESCRIPTION
This change causes a manual pipeline deactivation to
force all pipeline stages to reset, releasing any resources
they hold. It also performs a full reset on the speech context,
releasing it from any external management registered during
the activation.

This was necessary to support manual deactivation of the
Android speech recognizer, which would otherwise miss
the deactivate event due to its takeover of the speech
context.

@brentspell tagging you to double-check that I'm not missing anything about the intended semantics of the deactivate event and that clearing the transcript, etc., are all acceptable.