### PR TITLE
Fix: send timeout events for empty transcripts

### DIFF
--- a/src/main/java/io/spokestack/spokestack/SpeechPipeline.java
+++ b/src/main/java/io/spokestack/spokestack/SpeechPipeline.java
@@ -147,7 +147,7 @@ public final class SpeechPipeline implements AutoCloseable {
      */
     public void start() throws Exception {
         if (this.running) {
-            this.context.traceInfo(
+            this.context.traceDebug(
                   "attempting to start a running pipeline; ignoring");
             return;
         }

--- a/src/main/java/io/spokestack/spokestack/android/AndroidSpeechRecognizer.java
+++ b/src/main/java/io/spokestack/spokestack/android/AndroidSpeechRecognizer.java
@@ -208,25 +208,27 @@ public class AndroidSpeechRecognizer implements SpeechProcessor {
 
         @Override
         public void onPartialResults(Bundle partialResults) {
-            dispatchRecognition(partialResults, true);
+            dispatchRecognition(partialResults, false);
         }
 
         @Override
         public void onResults(Bundle results) {
-            dispatchRecognition(results, false);
+            dispatchRecognition(results, true);
             relinquishContext();
         }
 
-        private void dispatchRecognition(Bundle results, boolean isPartial) {
-            SpeechContext.Event event = (isPartial)
-                  ? SpeechContext.Event.PARTIAL_RECOGNIZE
-                  : SpeechContext.Event.RECOGNIZE;
+        private void dispatchRecognition(Bundle results, boolean isFinal) {
+            SpeechContext.Event event = (isFinal)
+                  ? SpeechContext.Event.RECOGNIZE
+                  : SpeechContext.Event.PARTIAL_RECOGNIZE;
             String transcript = extractTranscript(results);
             if (!transcript.equals("")) {
                 float confidence = extractConfidence(results);
                 this.context.setTranscript(transcript);
                 this.context.setConfidence(confidence);
                 this.context.dispatch(event);
+            } else if (isFinal) {
+                this.context.dispatch(SpeechContext.Event.TIMEOUT);
             }
         }
 

--- a/src/main/java/io/spokestack/spokestack/asr/SpokestackCloudRecognizer.java
+++ b/src/main/java/io/spokestack/spokestack/asr/SpokestackCloudRecognizer.java
@@ -151,6 +151,8 @@ public final class SpokestackCloudRecognizer implements SpeechProcessor {
                       ? SpeechContext.Event.RECOGNIZE
                       : SpeechContext.Event.PARTIAL_RECOGNIZE;
                 context.dispatch(event);
+            } else if (isFinal) {
+                context.dispatch(SpeechContext.Event.TIMEOUT);
             }
         }
 

--- a/src/main/java/io/spokestack/spokestack/microsoft/AzureSpeechRecognizer.java
+++ b/src/main/java/io/spokestack/spokestack/microsoft/AzureSpeechRecognizer.java
@@ -221,13 +221,16 @@ public class AzureSpeechRecognizer implements SpeechProcessor {
               SpeechRecognitionEventArgs recognitionArgs) {
             ResultReason reason = recognitionArgs.getResult().getReason();
             String transcript = recognitionArgs.getResult().getText();
+            boolean isFinal = (reason == ResultReason.RecognizedSpeech);
             if (!transcript.equals("")) {
-                if (reason == ResultReason.RecognizingSpeech) {
+                if (isFinal) {
+                    dispatchResult(transcript, SpeechContext.Event.RECOGNIZE);
+                } else if (reason == ResultReason.RecognizingSpeech) {
                     dispatchResult(transcript,
                           SpeechContext.Event.PARTIAL_RECOGNIZE);
-                } else if (reason == ResultReason.RecognizedSpeech) {
-                    dispatchResult(transcript, SpeechContext.Event.RECOGNIZE);
                 }
+            } else if (isFinal) {
+                this.speechContext.dispatch(SpeechContext.Event.TIMEOUT);
             }
         }
 

--- a/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
+++ b/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
@@ -123,7 +123,7 @@ public class SpeechPipelineTest implements OnSpeechEventListener {
             .setProperty("sample-rate", 16000)
             .setProperty("frame-width", 20)
             .setProperty("buffer-width", 300)
-            .setProperty("trace-level", EventTracer.Level.INFO.value())
+            .setProperty("trace-level", EventTracer.Level.DEBUG.value())
             .addOnSpeechEventListener(this)
             .build();
 

--- a/src/test/java/io/spokestack/spokestack/android/AndroidSpeechRecognizerTest.java
+++ b/src/test/java/io/spokestack/spokestack/android/AndroidSpeechRecognizerTest.java
@@ -148,6 +148,15 @@ public class AndroidSpeechRecognizerTest {
         // shouldn't fire when ASR is inactive
         assertEquals(6, listener.traces.size());
 
+        // empty final result
+        listener.clear();
+        transcript = "";
+        results = MockRecognizer.speechResults(transcript);
+        asrListener.onResults(results);
+        assertEquals(EventListener.TIMEOUT, listener.traces.get(0));
+        assertNull(listener.transcript);
+        assertNull(listener.error);
+
         // ASR received an error
         listener.clear();
         context.setActive(true);
@@ -249,6 +258,7 @@ public class AndroidSpeechRecognizerTest {
             this.confidence = 0.0;
             this.error = null;
             this.receivedPartial = false;
+            this.traces.clear();
         }
 
         @Override

--- a/src/test/java/io/spokestack/spokestack/asr/SpokestackCloudRecognizerTest.java
+++ b/src/test/java/io/spokestack/spokestack/asr/SpokestackCloudRecognizerTest.java
@@ -115,7 +115,7 @@ public class SpokestackCloudRecognizerTest implements OnSpeechEventListener {
 
         this.event = null;
         listener.onSpeech("", 0.9f, true);
-        assertNull(this.event);
+        assertEquals(SpeechContext.Event.TIMEOUT, this.event);
     }
 
     @Test

--- a/src/test/java/io/spokestack/spokestack/microsoft/AzureSpeechRecognizerTest.java
+++ b/src/test/java/io/spokestack/spokestack/microsoft/AzureSpeechRecognizerTest.java
@@ -52,6 +52,7 @@ public class AzureSpeechRecognizerTest implements OnSpeechEventListener {
     private SpeechRecognitionEventArgs partialRecognitionEvent;
     private SpeechRecognitionEventArgs emptyTextEvent;
     private SpeechRecognitionEventArgs recognitionEvent;
+    private SpeechRecognitionEventArgs timeoutEvent;
     private SpeechRecognitionCanceledEventArgs canceledEvent;
 
     @Before
@@ -98,6 +99,13 @@ public class AzureSpeechRecognizerTest implements OnSpeechEventListener {
         doReturn("test").when(finalResult).getText();
         doReturn(ResultReason.RecognizedSpeech).when(finalResult).getReason();
         when(recognitionEvent.getResult()).thenReturn(finalResult);
+
+        timeoutEvent = PowerMockito.mock(SpeechRecognitionEventArgs.class);
+        SpeechRecognitionResult timeoutResult =
+              mock(SpeechRecognitionResult.class);
+        doReturn("").when(timeoutResult).getText();
+        doReturn(ResultReason.RecognizedSpeech).when(timeoutResult).getReason();
+        when(timeoutEvent.getResult()).thenReturn(timeoutResult);
 
         canceledEvent = PowerMockito.mock(SpeechRecognitionCanceledEventArgs.class);
         doReturn(CancellationReason.Error).when(canceledEvent).getReason();
@@ -176,6 +184,13 @@ public class AzureSpeechRecognizerTest implements OnSpeechEventListener {
         assertEquals("test", context.getTranscript());
         assertEquals(1.0, context.getConfidence());
         assertEquals(SpeechContext.Event.RECOGNIZE, this.event);
+
+        context.reset();
+        new AzureSpeechRecognizer.RecognitionListener(context)
+              .onEvent(mockRecognizer, timeoutEvent);
+        assertEquals("", context.getTranscript());
+        assertEquals(0.0, context.getConfidence());
+        assertEquals(SpeechContext.Event.TIMEOUT, this.event);
 
         this.event = null;
         new AzureSpeechRecognizer.RecognitionListener(context)


### PR DESCRIPTION
This change sends a timeout event if an ASR service sends the
empty string as a transcript designated as a "final" result.

Previously only the Google speech recognizer sent a timeout under
these conditions; the other recognizers sent nothing.

I also threw in a demotion in log level for calling `start()` on a 
running pipeline, which really isn't worthy of an `INFO` log.

...and while I was there, I flipped `isPartial` to `isFinal` in
`AndroidSpeechRecognizer` to better match the other
services.