### PR TITLE
Allow clients to remove listeners

### DIFF
--- a/src/main/java/io/spokestack/spokestack/SpeechPipeline.java
+++ b/src/main/java/io/spokestack/spokestack/SpeechPipeline.java
@@ -141,6 +141,22 @@ public final class SpeechPipeline implements AutoCloseable {
     }
 
     /**
+     * Add a new listener to receive events from the speech pipeline.
+     * @param listener The listener to add.
+     */
+    public void addListener(OnSpeechEventListener listener) {
+        this.context.addOnSpeechEventListener(listener);
+    }
+
+    /**
+     * Remove a pipeline listener, allowing it to be garbage collected.
+     * @param listener The listener to remove.
+     */
+    public void removeListener(OnSpeechEventListener listener) {
+        this.context.removeOnSpeechEventListener(listener);
+    }
+
+    /**
      * starts up the speech pipeline.
      *
      * @throws Exception on configuration/startup error

--- a/src/main/java/io/spokestack/spokestack/Spokestack.java
+++ b/src/main/java/io/spokestack/spokestack/Spokestack.java
@@ -241,6 +241,43 @@ public final class Spokestack extends SpokestackAdapter
 
     // listeners
 
+    /**
+     * Add a new listener to receive events from Spokestack subsystems.
+     *
+     * @param listener A listener that will receive events from all Spokestack
+     *                 subsystems.
+     */
+    public void addListener(SpokestackAdapter listener) {
+        this.listeners.add(listener);
+        if (this.speechPipeline != null) {
+            this.speechPipeline.addListener(listener);
+        }
+        if (this.nlu != null) {
+            this.nlu.addListener(listener);
+        }
+        if (this.tts != null) {
+            this.tts.addListener(listener);
+        }
+    }
+
+    /**
+     * Remove a Spokestack event listener, allowing it to be garbage collected.
+     *
+     * @param listener The listener to be removed.
+     */
+    public void removeListener(SpokestackAdapter listener) {
+        this.listeners.remove(listener);
+        if (this.speechPipeline != null) {
+            this.speechPipeline.removeListener(listener);
+        }
+        if (this.nlu != null) {
+            this.nlu.removeListener(listener);
+        }
+        if (this.tts != null) {
+            this.tts.removeListener(listener);
+        }
+    }
+
     @Override
     public void onEvent(@NotNull SpeechContext.Event event,
                         @NotNull SpeechContext context) {
@@ -284,7 +321,6 @@ public final class Spokestack extends SpokestackAdapter
      * @see Builder#Builder()
      */
     public static class Builder {
-        private final SpeechConfig speechConfig;
         private final SpeechPipeline.Builder pipelineBuilder;
         private final TensorflowNLU.Builder nluBuilder;
         private final TTSManager.Builder ttsBuilder;
@@ -296,6 +332,7 @@ public final class Spokestack extends SpokestackAdapter
         private boolean useTTS = true;
         private boolean useTTSPlayback = true;
 
+        private SpeechConfig speechConfig;
         private TranscriptEditor transcriptEditor;
         private Context appContext;
         private Lifecycle appLifecycle;
@@ -415,7 +452,7 @@ public final class Spokestack extends SpokestackAdapter
             config.put("frame-width", DEFAULT_FRAME_WIDTH);
             config.put("buffer-width", DEFAULT_BUFFER_WIDTH);
 
-            // NLU
+            // other
             config.put("trace-level", EventTracer.Level.ERROR.value());
         }
 
@@ -475,6 +512,7 @@ public final class Spokestack extends SpokestackAdapter
          * @return the updated builder
          */
         public Builder setConfig(SpeechConfig config) {
+            this.speechConfig = config;
             this.pipelineBuilder.setConfig(config);
             this.nluBuilder.setConfig(config);
             this.ttsBuilder.setConfig(config);

--- a/src/main/java/io/spokestack/spokestack/nlu/NLUContext.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/NLUContext.java
@@ -42,6 +42,15 @@ public final class NLUContext {
     }
 
     /**
+     * Remove a trace listener, allowing it to be garbage collected.
+     *
+     * @param listener the listener to remove
+     */
+    public void removeTraceListener(TraceListener listener) {
+        this.listeners.remove(listener);
+    }
+
+    /**
      * @return the metadata for the current request.
      */
     public HashMap<String, Object> getRequestMetadata() {

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TensorflowNLU.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TensorflowNLU.java
@@ -61,15 +61,15 @@ public final class TensorflowNLU implements NLUService {
     private final ExecutorService executor =
           Executors.newSingleThreadExecutor();
     private final TextEncoder textEncoder;
+    private final NLUContext context;
+    private final int sepTokenId;
+    private final int padTokenId;
+    private final Thread loadThread;
 
     private TensorflowModel nluModel = null;
     private TFNLUOutput outputParser = null;
-    private NLUContext context;
     private int maxTokens;
-    private int sepTokenId;
-    private int padTokenId;
 
-    private Thread loadThread;
     private volatile boolean ready = false;
 
     /**
@@ -260,12 +260,28 @@ public final class TensorflowNLU implements NLUService {
     }
 
     /**
+     * Add a new listener to receive trace events from the NLU subsystem.
+     * @param listener The listener to add.
+     */
+    public void addListener(TraceListener listener) {
+        this.context.addTraceListener(listener);
+    }
+
+    /**
+     * Remove a trace listener, allowing it to be garbage collected.
+     * @param listener The listener to remove.
+     */
+    public void removeListener(TraceListener listener) {
+        this.context.removeTraceListener(listener);
+    }
+
+    /**
      * Fluent builder interface for initializing a TensorFlow NLU model.
      */
     public static class Builder {
+        private final List<TraceListener> traceListeners = new ArrayList<>();
+        private final Map<String, String> slotParserClasses = new HashMap<>();
         private NLUContext context;
-        private List<TraceListener> traceListeners = new ArrayList<>();
-        private Map<String, String> slotParserClasses = new HashMap<>();
         private SpeechConfig config = new SpeechConfig();
         private TensorflowModel.Loader modelLoader;
         private ThreadFactory threadFactory;

--- a/src/main/java/io/spokestack/spokestack/tts/TTSManager.java
+++ b/src/main/java/io/spokestack/spokestack/tts/TTSManager.java
@@ -151,6 +151,22 @@ public final class TTSManager implements AutoCloseable {
         }
     }
 
+    /**
+     * Add a new listener to receive events from the TTS subsystem.
+     * @param listener The listener to add.
+     */
+    public void addListener(TTSListener listener) {
+        this.listeners.add(listener);
+    }
+
+    /**
+     * Remove a TTS listener, allowing it to be garbage collected.
+     * @param listener The listener to remove.
+     */
+    public void removeListener(TTSListener listener) {
+        this.listeners.remove(listener);
+    }
+
     @Override
     public void close() {
         release();


### PR DESCRIPTION
This change allows clients to remove event listeners for
the NLU and TTS subsystems, extending the capability to the
new Spokestack wrapper.

Previously, only speech pipeline listeners could be removed,
which created a potential memory leak if clients had implemented
the other listeners in ephemeral classes like Activity.

The test uses changes introduced in #111 , so this is a draft until that one is reviewed and merged.