### PR TITLE
breaking: refactor to make NLU interchangeable

### DIFF
--- a/src/main/java/io/spokestack/spokestack/Spokestack.java
+++ b/src/main/java/io/spokestack/spokestack/Spokestack.java
@@ -2,9 +2,8 @@ package io.spokestack.spokestack;
 
 import android.content.Context;
 import androidx.lifecycle.Lifecycle;
+import io.spokestack.spokestack.nlu.NLUManager;
 import io.spokestack.spokestack.nlu.NLUResult;
-import io.spokestack.spokestack.nlu.NLUService;
-import io.spokestack.spokestack.nlu.tensorflow.TensorflowNLU;
 import io.spokestack.spokestack.tts.SynthesisRequest;
 import io.spokestack.spokestack.tts.TTSManager;
 import io.spokestack.spokestack.util.AsyncResult;
@@ -65,7 +64,7 @@ import static io.spokestack.spokestack.SpeechPipeline.DEFAULT_SAMPLE_RATE;
  * </p>
  *
  * @see SpeechPipeline
- * @see TensorflowNLU
+ * @see io.spokestack.spokestack.nlu.tensorflow.TensorflowNLU
  * @see TTSManager
  */
 public final class Spokestack extends SpokestackAdapter
@@ -75,7 +74,7 @@ public final class Spokestack extends SpokestackAdapter
     private final boolean autoClassify;
     private final TranscriptEditor transcriptEditor;
     private SpeechPipeline speechPipeline;
-    private TensorflowNLU nlu;
+    private NLUManager nlu;
     private TTSManager tts;
 
     /**
@@ -109,6 +108,35 @@ public final class Spokestack extends SpokestackAdapter
         }
     }
 
+    /**
+     * Package-private constructor used for testing with an injected NLU.
+     *
+     * @param builder    The builder to use for everything but NLU.
+     * @param nluManager The NLU manager to inject.
+     */
+    Spokestack(Builder builder, NLUManager nluManager) throws Exception {
+        this.listeners = new ArrayList<>();
+        this.listeners.addAll(builder.listeners);
+        this.autoClassify = builder.autoClassify;
+        this.transcriptEditor = builder.transcriptEditor;
+        if (builder.useAsr) {
+            this.speechPipeline = builder.getPipelineBuilder()
+                  .addOnSpeechEventListener(this)
+                  .build();
+        }
+        if (builder.useNLU) {
+            this.nlu = nluManager;
+        }
+        if (builder.useTTS) {
+            if (!builder.useTTSPlayback) {
+                builder.ttsBuilder.setOutputClass(null);
+            }
+            this.tts = builder.getTtsBuilder()
+                  .addTTSListener(this)
+                  .build();
+        }
+    }
+
     // speech pipeline
 
     /**
@@ -126,14 +154,18 @@ public final class Spokestack extends SpokestackAdapter
      *                   pipeline.
      */
     public void start() throws Exception {
-        this.speechPipeline.start();
+        if (this.speechPipeline != null) {
+            this.speechPipeline.start();
+        }
     }
 
     /**
      * Stops the speech pipeline and releases all its internal resources.
      */
     public void stop() {
-        this.speechPipeline.stop();
+        if (this.speechPipeline != null) {
+            this.speechPipeline.stop();
+        }
     }
 
     /**
@@ -142,7 +174,9 @@ public final class Spokestack extends SpokestackAdapter
      * conjunction with a microphone button.
      */
     public void activate() {
-        this.speechPipeline.activate();
+        if (this.speechPipeline != null) {
+            this.speechPipeline.activate();
+        }
     }
 
     /**
@@ -156,15 +190,17 @@ public final class Spokestack extends SpokestackAdapter
      * </p>
      */
     public void deactivate() {
-        this.speechPipeline.deactivate();
+        if (this.speechPipeline != null) {
+            this.speechPipeline.deactivate();
+        }
     }
 
     // NLU
 
     /**
-     * @return The NLU service currently in use.
+     * @return The NLU manager currently in use.
      */
-    public NLUService getNlu() {
+    public NLUManager getNlu() {
         return nlu;
     }
 
@@ -184,7 +220,10 @@ public final class Spokestack extends SpokestackAdapter
      * classification.
      */
     public AsyncResult<NLUResult> classify(String utterance) {
-        return classifyInternal(utterance);
+        if (this.nlu != null) {
+            return classifyInternal(utterance);
+        }
+        return null;
     }
 
     // TTS
@@ -205,7 +244,9 @@ public final class Spokestack extends SpokestackAdapter
      * @throws Exception If there is an error constructing TTS components.
      */
     public void prepareTts() throws Exception {
-        this.tts.prepare();
+        if (this.tts != null) {
+            this.tts.prepare();
+        }
     }
 
     /**
@@ -219,7 +260,9 @@ public final class Spokestack extends SpokestackAdapter
      * </p>
      */
     public void releaseTts() {
-        this.tts.release();
+        if (this.tts != null) {
+            this.tts.release();
+        }
     }
 
     /**
@@ -229,14 +272,18 @@ public final class Spokestack extends SpokestackAdapter
      * @param request The synthesis request data.
      */
     public void synthesize(SynthesisRequest request) {
-        this.tts.synthesize(request);
+        if (this.tts != null) {
+            this.tts.synthesize(request);
+        }
     }
 
     /**
      * Stops playback of any playing or queued synthesis results.
      */
     public void stopPlayback() {
-        this.tts.stopPlayback();
+        if (this.tts != null) {
+            this.tts.stopPlayback();
+        }
     }
 
     // listeners
@@ -294,6 +341,11 @@ public final class Spokestack extends SpokestackAdapter
         }
     }
 
+    @Override
+    public void nluResult(@NotNull NLUResult result) {
+        super.nluResult(result);
+    }
+
     private AsyncResult<NLUResult> classifyInternal(String text) {
         AsyncResult<NLUResult> result =
               this.nlu.classify(text);
@@ -322,7 +374,7 @@ public final class Spokestack extends SpokestackAdapter
      */
     public static class Builder {
         private final SpeechPipeline.Builder pipelineBuilder;
-        private final TensorflowNLU.Builder nluBuilder;
+        private final NLUManager.Builder nluBuilder;
         private final TTSManager.Builder ttsBuilder;
         private final List<SpokestackAdapter> listeners = new ArrayList<>();
 
@@ -434,7 +486,7 @@ public final class Spokestack extends SpokestackAdapter
                         .setConfig(this.speechConfig)
                         .useProfile(profileClass);
             this.nluBuilder =
-                  new TensorflowNLU.Builder().setConfig(this.speechConfig);
+                  new NLUManager.Builder().setConfig(this.speechConfig);
             String ttsServiceClass =
                   "io.spokestack.spokestack.tts.SpokestackTTSService";
             String ttsOutputClass =
@@ -461,14 +513,12 @@ public final class Spokestack extends SpokestackAdapter
          * for testing.
          *
          * @param pipeline the speech pipeline builder
-         * @param nlu      the NLU builder
          * @param tts      the TTS builder
          */
-        Builder(SpeechPipeline.Builder pipeline, TensorflowNLU.Builder nlu,
-                TTSManager.Builder tts) {
+        Builder(SpeechPipeline.Builder pipeline, TTSManager.Builder tts) {
             this.speechConfig = new SpeechConfig();
             this.pipelineBuilder = pipeline;
-            this.nluBuilder = nlu;
+            this.nluBuilder = new NLUManager.Builder();
             this.ttsBuilder = tts;
         }
 
@@ -482,7 +532,7 @@ public final class Spokestack extends SpokestackAdapter
         /**
          * @return The builder used to configure the NLU subsystem.
          */
-        public TensorflowNLU.Builder getNluBuilder() {
+        public NLUManager.Builder getNluBuilder() {
             return nluBuilder;
         }
 

--- a/src/main/java/io/spokestack/spokestack/Spokestack.java
+++ b/src/main/java/io/spokestack/spokestack/Spokestack.java
@@ -4,6 +4,10 @@ import android.content.Context;
 import androidx.lifecycle.Lifecycle;
 import io.spokestack.spokestack.nlu.NLUManager;
 import io.spokestack.spokestack.nlu.NLUResult;
+import io.spokestack.spokestack.nlu.tensorflow.parsers.DigitsParser;
+import io.spokestack.spokestack.nlu.tensorflow.parsers.IdentityParser;
+import io.spokestack.spokestack.nlu.tensorflow.parsers.IntegerParser;
+import io.spokestack.spokestack.nlu.tensorflow.parsers.SelsetParser;
 import io.spokestack.spokestack.tts.SynthesisRequest;
 import io.spokestack.spokestack.tts.TTSManager;
 import io.spokestack.spokestack.util.AsyncResult;
@@ -504,6 +508,12 @@ public final class Spokestack extends SpokestackAdapter
             config.put("frame-width", DEFAULT_FRAME_WIDTH);
             config.put("buffer-width", DEFAULT_BUFFER_WIDTH);
 
+            // nlu
+            config.put("slot-digits", DigitsParser.class.getName());
+            config.put("slot-integer", IntegerParser.class.getName());
+            config.put("slot-selset", SelsetParser.class.getName());
+            config.put("slot-entity", IdentityParser.class.getName());
+
             // other
             config.put("trace-level", EventTracer.Level.ERROR.value());
         }
@@ -557,6 +567,12 @@ public final class Spokestack extends SpokestackAdapter
          *     <li>frame-width</li>
          *     <li>buffer-width</li>
          * </ul>
+         *
+         * <p>
+         * Other module builders may set their own default values; builders for
+         * the modules in use should be consulted before overwriting their
+         * configuration.
+         * </p>
          *
          * @param config configuration to attach
          * @return the updated builder

--- a/src/main/java/io/spokestack/spokestack/SpokestackAdapter.java
+++ b/src/main/java/io/spokestack/spokestack/SpokestackAdapter.java
@@ -72,7 +72,12 @@ public abstract class SpokestackAdapter implements
      */
     @Override
     public void call(@NotNull NLUResult result) {
-        nluResult(result);
+        Throwable error = result.getError();
+        if (error != null) {
+            onError(error);
+        } else {
+            nluResult(result);
+        }
     }
 
     /**

--- a/src/main/java/io/spokestack/spokestack/nlu/NLUManager.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/NLUManager.java
@@ -2,6 +2,10 @@ package io.spokestack.spokestack.nlu;
 
 import io.spokestack.spokestack.SpeechConfig;
 import io.spokestack.spokestack.nlu.tensorflow.TensorflowNLU;
+import io.spokestack.spokestack.nlu.tensorflow.parsers.DigitsParser;
+import io.spokestack.spokestack.nlu.tensorflow.parsers.IdentityParser;
+import io.spokestack.spokestack.nlu.tensorflow.parsers.IntegerParser;
+import io.spokestack.spokestack.nlu.tensorflow.parsers.SelsetParser;
 import io.spokestack.spokestack.util.AsyncResult;
 import io.spokestack.spokestack.util.EventTracer;
 import io.spokestack.spokestack.util.TraceListener;
@@ -88,6 +92,10 @@ public final class NLUManager {
          */
         public Builder() {
             config.put("trace-level", EventTracer.Level.ERROR.value());
+            config.put("slot-digits", DigitsParser.class.getName());
+            config.put("slot-integer", IntegerParser.class.getName());
+            config.put("slot-selset", SelsetParser.class.getName());
+            config.put("slot-entity", IdentityParser.class.getName());
             this.serviceClass = TensorflowNLU.class.getCanonicalName();
         }
 

--- a/src/main/java/io/spokestack/spokestack/nlu/NLUManager.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/NLUManager.java
@@ -1,0 +1,157 @@
+package io.spokestack.spokestack.nlu;
+
+import io.spokestack.spokestack.SpeechConfig;
+import io.spokestack.spokestack.nlu.tensorflow.TensorflowNLU;
+import io.spokestack.spokestack.util.AsyncResult;
+import io.spokestack.spokestack.util.EventTracer;
+import io.spokestack.spokestack.util.TraceListener;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Manager for natural language understanding (NLU) components in Spokestack.
+ *
+ * <p>
+ * Spokestack's NLU manager follows the same setup pattern as its {@link
+ * io.spokestack.spokestack.SpeechPipeline} and {@link io.spokestack.spokestack.tts.TTSManager}
+ * modules. The manager constructs the component ultimately responsible for
+ * classification (an {@link NLUService}) and manages the context required to
+ * perform these classifications and dispatch events to registered listeners.
+ * </p>
+ */
+public final class NLUManager {
+    private final NLUService nlu;
+    private final NLUContext context;
+
+    /**
+     * Constructs a new {@code NLUManager} with an initialized NLU service.
+     *
+     * @param builder builder with configuration parameters
+     * @throws Exception If there is an error constructing the service.
+     */
+    private NLUManager(Builder builder) throws Exception {
+        this.context = builder.context;
+        this.nlu = buildService(builder);
+    }
+
+    private NLUService buildService(Builder builder) throws Exception {
+        Object constructed = Class
+              .forName(builder.serviceClass)
+              .getConstructor(SpeechConfig.class, NLUContext.class)
+              .newInstance(builder.config, builder.context);
+        return (NLUService) constructed;
+    }
+
+    /**
+     * Classify a user utterance, returning a wrapper that can either block
+     * until the classification is complete or call a registered callback when
+     * the result is ready.
+     *
+     * @param utterance The utterance to classify.
+     * @return An object representing the result of the asynchronous
+     * classification.
+     */
+    public AsyncResult<NLUResult> classify(String utterance) {
+        return this.nlu.classify(utterance, this.context);
+    }
+
+    /**
+     * Add a new listener to receive trace events from the NLU subsystem.
+     *
+     * @param listener The listener to add.
+     */
+    public void addListener(TraceListener listener) {
+        this.context.addTraceListener(listener);
+    }
+
+    /**
+     * Remove a trace listener, allowing it to be garbage collected.
+     *
+     * @param listener The listener to remove.
+     */
+    public void removeListener(TraceListener listener) {
+        this.context.removeTraceListener(listener);
+    }
+
+    /**
+     * Fluent builder interface for initializing an NLU manager.
+     */
+    public static class Builder {
+        private final List<TraceListener> traceListeners = new ArrayList<>();
+        private NLUContext context;
+        private SpeechConfig config = new SpeechConfig();
+        private String serviceClass;
+
+        /**
+         * Creates a new builder instance.
+         */
+        public Builder() {
+            config.put("trace-level", EventTracer.Level.ERROR.value());
+            this.serviceClass = TensorflowNLU.class.getCanonicalName();
+        }
+
+        /**
+         * Sets the name of the NLU service class to be used.
+         *
+         * @param className The name of the NLU service class to be used.
+         * @return this
+         */
+        public Builder setServiceClass(String className) {
+            this.serviceClass = className;
+            return this;
+        }
+
+        /**
+         * Attaches a configuration object, overwriting any existing
+         * configuration.
+         *
+         * @param value configuration to attach
+         * @return this
+         */
+        public Builder setConfig(SpeechConfig value) {
+            this.config = value;
+            return this;
+        }
+
+        /**
+         * Sets a configuration value.
+         *
+         * @param key   configuration property name
+         * @param value property value
+         * @return this
+         */
+        public Builder setProperty(String key, Object value) {
+            config.put(key, value);
+            return this;
+        }
+
+        /**
+         * Adds a trace listener to receive events from the NLU system.
+         *
+         * @param listener the listener to register
+         * @return this
+         */
+        public Builder addTraceListener(TraceListener listener) {
+            this.traceListeners.add(listener);
+            return this;
+        }
+
+        /**
+         * Create a new NLU service, automatically loading any necessary
+         * resources in the background. Any errors encountered during loading
+         * will be reported to registered {@link TraceListener}s.
+         *
+         * @return An initialized {@code NLUManager} instance
+         * @throws Exception If there is an error constructing the NLU service.
+         */
+        public NLUManager build() throws Exception {
+            this.context = new NLUContext(this.config);
+            for (TraceListener listener : this.traceListeners) {
+                this.context.addTraceListener(listener);
+            }
+            return new NLUManager(this);
+        }
+
+    }
+}

--- a/src/main/java/io/spokestack/spokestack/nlu/NLUService.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/NLUService.java
@@ -5,6 +5,12 @@ import io.spokestack.spokestack.util.AsyncResult;
 /**
  * A simple interface for components that provide intent classification and slot
  * recognition, either on-device or via a network request.
+ *
+ * <p>
+ * To participate in Spokestack's {@link NLUManager}, an NLUService must have a
+ * constructor that accepts instances of {@link io.spokestack.spokestack.SpeechConfig}
+ * and {@link NLUContext}.
+ * </p>
  */
 public interface NLUService {
 

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TFNLUOutput.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TFNLUOutput.java
@@ -26,6 +26,7 @@ final class TFNLUOutput {
 
     /**
      * Set the parsers that should be used for a collection of slot types.
+     *
      * @param parsers A map of slot type to the parser used for that type.
      */
     public void registerSlotParsers(Map<String, SlotParser> parsers) {
@@ -35,7 +36,7 @@ final class TFNLUOutput {
     /**
      * Extract the intent from the model's output tensor.
      *
-     * @param output   The output tensor containing the intent prediction.
+     * @param output The output tensor containing the intent prediction.
      * @return A tuple consisting of the intent from the model's output tensor
      * and the model's posterior probability (confidence value) for that
      * prediction.
@@ -50,10 +51,10 @@ final class TFNLUOutput {
      * Extract the slot values captured for a specific utterance from the
      * model's slot tag output tensor.
      *
-     * @param context  The context used to communicate trace events.
-     * @param encoded  The original encoded input, used to determine string
-     *                 values for model output.
-     * @param output   The output tensor containing slot tag predictions.
+     * @param context The context used to communicate trace events.
+     * @param encoded The original encoded input, used to determine string
+     *                values for model output.
+     * @param output  The output tensor containing slot tag predictions.
      * @return A map of slot name to raw string values.
      */
     public Map<String, String> getSlots(
@@ -183,7 +184,12 @@ final class TFNLUOutput {
     }
 
     private Slot parseSlotValue(Metadata.Slot metaSlot, String slotValue) {
-        SlotParser parser = this.slotParsers.get(metaSlot.getType());
+        String slotType = metaSlot.getType();
+        SlotParser parser = this.slotParsers.get(slotType);
+        if (parser == null) {
+            throw new IllegalArgumentException(
+                  "No parser found for \"" + slotType + "\" slot");
+        }
         String slotName = metaSlot.getCaptureName();
         try {
             Object parsed = parser.parse(metaSlot.getFacets(), slotValue);

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TensorflowNLU.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TensorflowNLU.java
@@ -166,13 +166,13 @@ public final class TensorflowNLU implements NLUService {
                       .getConstructor()
                       .newInstance();
                 slotParsers.put(slotType, parser);
-                this.outputParser.registerSlotParsers(slotParsers);
-                this.ready = true;
             } catch (Exception e) {
                 this.context.traceError("Error loading slot parsers: %s",
                       e.getLocalizedMessage());
             }
         }
+        this.outputParser.registerSlotParsers(slotParsers);
+        this.ready = true;
     }
 
     private void loadModel(TensorflowModel.Loader loader,

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TensorflowNLU.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TensorflowNLU.java
@@ -8,7 +8,6 @@ import io.spokestack.spokestack.nlu.NLUContext;
 import io.spokestack.spokestack.nlu.NLUResult;
 import io.spokestack.spokestack.nlu.NLUService;
 import io.spokestack.spokestack.nlu.Slot;
-import io.spokestack.spokestack.util.TraceListener;
 import io.spokestack.spokestack.nlu.tensorflow.parsers.DigitsParser;
 import io.spokestack.spokestack.nlu.tensorflow.parsers.IdentityParser;
 import io.spokestack.spokestack.nlu.tensorflow.parsers.IntegerParser;
@@ -16,6 +15,7 @@ import io.spokestack.spokestack.nlu.tensorflow.parsers.SelsetParser;
 import io.spokestack.spokestack.tensorflow.TensorflowModel;
 import io.spokestack.spokestack.util.AsyncResult;
 import io.spokestack.spokestack.util.EventTracer;
+import io.spokestack.spokestack.util.TraceListener;
 import io.spokestack.spokestack.util.Tuple;
 
 import java.io.FileReader;
@@ -55,19 +55,25 @@ import java.util.concurrent.ThreadFactory;
  *      <b>wordpiece-vocab-path</b> (string, required): file system path to the
  *      wordpiece vocabulary file used by the wordpiece token encoder.
  *   </li>
+ *   <li>
+ *      <b>slot-&lt;slotType&gt;</b> (string, optional): class name of a slot
+ *      parser capable of parsing slots with the {@code slotType} type. For
+ *      example, a custom slot parser used to parse slots listed as {@code user}
+ *      in the NLU metadata should be provided under the key {@code slot-user}.
+ *   </li>
  * </ul>
  */
 public final class TensorflowNLU implements NLUService {
     private final ExecutorService executor =
           Executors.newSingleThreadExecutor();
-    private final TextEncoder textEncoder;
     private final NLUContext context;
-    private final int sepTokenId;
-    private final int padTokenId;
-    private final Thread loadThread;
 
-    private TensorflowModel nluModel = null;
-    private TFNLUOutput outputParser = null;
+    private TextEncoder textEncoder;
+    private int sepTokenId;
+    private int padTokenId;
+    private Thread loadThread;
+    private TensorflowModel nluModel;
+    private TFNLUOutput outputParser;
     private int maxTokens;
 
     private volatile boolean ready = false;
@@ -80,18 +86,75 @@ public final class TensorflowNLU implements NLUService {
      * @param builder builder with configuration parameters
      */
     private TensorflowNLU(Builder builder) {
-        String modelPath = builder.config.getString("nlu-model-path");
-        String metadataPath = builder.config.getString("nlu-metadata-path");
         this.context = builder.context;
-        this.textEncoder = builder.textEncoder;
-        this.loadThread = builder.threadFactory.newThread(
+        SpeechConfig config = transferSlotParsers(
+              builder.slotParserClasses, builder.config);
+        load(config,
+              builder.textEncoder,
+              builder.modelLoader,
+              builder.threadFactory);
+    }
+
+    private SpeechConfig transferSlotParsers(Map<String, String> parserClasses,
+                                             SpeechConfig config) {
+        for (Map.Entry<String, String> parser : parserClasses.entrySet()) {
+            String key = "slot-" + parser.getKey();
+            if (!config.containsKey(key)) {
+                config.put(key, parser.getValue());
+            }
+        }
+        return config;
+    }
+
+    /**
+     * Public constructor for {@code NLUManager} participation. Uses a {@link
+     * WordpieceTextEncoder} and a default TensorFlow model loader.
+     *
+     * <p>
+     * The model and text encoder are loaded on a background thread.
+     * </p>
+     *
+     * @param speechConfig configuration properties
+     * @param nluContext   The context used to register listeners and deliver
+     *                     trace and error events.
+     */
+    public TensorflowNLU(SpeechConfig speechConfig, NLUContext nluContext) {
+        this.context = nluContext;
+        load(speechConfig,
+              new WordpieceTextEncoder(speechConfig, this.context),
+              new TensorflowModel.Loader(),
+              Thread::new);
+    }
+
+    private void load(SpeechConfig config,
+                      TextEncoder encoder,
+                      TensorflowModel.Loader loader,
+                      ThreadFactory threadFactory) {
+        String modelPath = config.getString("nlu-model-path");
+        String metadataPath = config.getString("nlu-metadata-path");
+        Map<String, String> slotParsers = getSlotParsers(config);
+        this.textEncoder = encoder;
+        this.loadThread = threadFactory.newThread(
               () -> {
-                  loadModel(builder.modelLoader, metadataPath, modelPath);
-                  initParsers(builder.slotParserClasses);
+                  loadModel(loader, metadataPath, modelPath);
+                  initParsers(slotParsers);
               });
         this.loadThread.start();
-        this.padTokenId = this.textEncoder.encodeSingle("[PAD]");
-        this.sepTokenId = this.textEncoder.encodeSingle("[SEP]");
+
+        this.padTokenId = encoder.encodeSingle("[PAD]");
+        this.sepTokenId = encoder.encodeSingle("[SEP]");
+    }
+
+    private Map<String, String> getSlotParsers(SpeechConfig config) {
+        HashMap<String, String> slotParsers = new HashMap<>();
+
+        for (Map.Entry<String, Object> prop : config.getParams().entrySet()) {
+            if (prop.getKey().startsWith("slot-")) {
+                String slotType = prop.getKey().replace("slot-", "");
+                slotParsers.put(slotType, String.valueOf(prop.getValue()));
+            }
+        }
+        return slotParsers;
     }
 
     private void initParsers(Map<String, String> parserClasses) {
@@ -104,6 +167,7 @@ public final class TensorflowNLU implements NLUService {
                       .newInstance();
                 slotParsers.put(slotType, parser);
                 this.outputParser.registerSlotParsers(slotParsers);
+                this.ready = true;
             } catch (Exception e) {
                 this.context.traceError("Error loading slot parsers: %s",
                       e.getLocalizedMessage());
@@ -126,7 +190,6 @@ public final class TensorflowNLU implements NLUService {
                   / this.nluModel.getInputSize();
             this.outputParser = new TFNLUOutput(metadata);
             warmup();
-            this.ready = true;
         } catch (IOException e) {
             this.context.traceError("Error loading NLU model: %s",
                   e.getLocalizedMessage());
@@ -261,6 +324,7 @@ public final class TensorflowNLU implements NLUService {
 
     /**
      * Add a new listener to receive trace events from the NLU subsystem.
+     *
      * @param listener The listener to add.
      */
     public void addListener(TraceListener listener) {
@@ -269,6 +333,7 @@ public final class TensorflowNLU implements NLUService {
 
     /**
      * Remove a trace listener, allowing it to be garbage collected.
+     *
      * @param listener The listener to remove.
      */
     public void removeListener(TraceListener listener) {
@@ -328,7 +393,7 @@ public final class TensorflowNLU implements NLUService {
          * @param loader The TensorFlow model loader to use.
          * @return this
          */
-        public Builder setModelLoader(TensorflowModel.Loader loader) {
+        Builder setModelLoader(TensorflowModel.Loader loader) {
             this.modelLoader = loader;
             return this;
         }
@@ -339,7 +404,7 @@ public final class TensorflowNLU implements NLUService {
          * @param encoder The text encoder to use.
          * @return this
          */
-        public Builder setTextEncoder(TextEncoder encoder) {
+        Builder setTextEncoder(TextEncoder encoder) {
             this.textEncoder = encoder;
             return this;
         }

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/WordpieceTextEncoder.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/WordpieceTextEncoder.java
@@ -28,11 +28,12 @@ final class WordpieceTextEncoder implements TextEncoder {
     private static final String UNKNOWN = "[UNK]";
     private static final String SUFFIX_MARKER = "##";
 
-    private NLUContext context;
+    private final Thread loadThread;
+    private final NLUContext context;
+
     private HashMap<String, Integer> vocabulary;
 
     private volatile boolean ready = false;
-    private Thread loadThread;
 
     /**
      * Creates a new Wordpiece token encoder.
@@ -56,7 +57,7 @@ final class WordpieceTextEncoder implements TextEncoder {
      *                      thread.
      */
     WordpieceTextEncoder(SpeechConfig config, NLUContext nluContext,
-                                ThreadFactory threadFactory) {
+                         ThreadFactory threadFactory) {
         String vocabFile = config.getString("wordpiece-vocab-path");
         this.context = nluContext;
         this.loadThread = threadFactory.newThread(() -> loadVocab(vocabFile));

--- a/src/test/java/io/spokestack/spokestack/nlu/tensorflow/NLUTestUtils.java
+++ b/src/test/java/io/spokestack/spokestack/nlu/tensorflow/NLUTestUtils.java
@@ -1,11 +1,14 @@
 package io.spokestack.spokestack.nlu.tensorflow;
 
-import android.os.SystemClock;
 import com.google.gson.Gson;
 import com.google.gson.stream.JsonReader;
 import io.spokestack.spokestack.SpeechConfig;
+import io.spokestack.spokestack.nlu.NLUContext;
+import io.spokestack.spokestack.nlu.NLUManager;
 import io.spokestack.spokestack.nlu.NLUResult;
+import io.spokestack.spokestack.nlu.NLUService;
 import io.spokestack.spokestack.tensorflow.TensorflowModel;
+import io.spokestack.spokestack.util.AsyncResult;
 
 import java.io.FileNotFoundException;
 import java.io.FileReader;
@@ -16,7 +19,6 @@ import java.util.List;
 import java.util.concurrent.Future;
 
 import static org.mockito.Mockito.*;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 public class NLUTestUtils {
 
@@ -25,6 +27,13 @@ public class NLUTestUtils {
               .put("nlu-model-path", "model-path")
               .put("nlu-metadata-path", "src/test/resources/nlu.json")
               .put("wordpiece-vocab-path", "src/test/resources/vocab.txt");
+    }
+
+    public static NLUManager mockManager() throws Exception {
+        return new NLUManager.Builder()
+              .setServiceClass(NLUTestUtils.class.getCanonicalName()
+                    + "$MockNLU")
+              .build();
     }
 
     public static class TestModel extends TensorflowModel {
@@ -133,5 +142,26 @@ public class NLUTestUtils {
             encoded.setOriginalIndices(originalIndices);
             return encoded;
         }
+    }
+
+    public static class MockNLU implements NLUService {
+
+        public MockNLU(SpeechConfig config, NLUContext context) {
+            // empty constructor so it can be built by the manager
+        }
+
+        @Override
+        public AsyncResult<NLUResult> classify(
+              String utterance,
+              NLUContext context
+        ) {
+            AsyncResult<NLUResult> result = new AsyncResult<>(() ->
+                  new NLUResult.Builder(utterance)
+                        .withIntent(utterance)
+                        .build());
+            result.run();
+            return result;
+        }
+
     }
 }


### PR DESCRIPTION
This introduces an NLUManager component capable of dispatching
classification to different backends. It constitutes a breaking
change for the `Spokestack` class since the type of its `nlu`
field has changed.

Slot parsers can now be registered in a `SpeechConfig` object via a `slot-<type>` key mapped to the name of the parser class for that type, like other pluggable Spokestack components.