### PR TITLE
Dialogue wiring

### DIFF
--- a/src/main/java/io/spokestack/spokestack/SpokestackAdapter.java
+++ b/src/main/java/io/spokestack/spokestack/SpokestackAdapter.java
@@ -1,5 +1,7 @@
 package io.spokestack.spokestack;
 
+import io.spokestack.spokestack.dialogue.DialogueEvent;
+import io.spokestack.spokestack.dialogue.DialogueListener;
 import io.spokestack.spokestack.nlu.NLUResult;
 import io.spokestack.spokestack.tts.TTSEvent;
 import io.spokestack.spokestack.tts.TTSListener;
@@ -19,6 +21,7 @@ import org.jetbrains.annotations.NotNull;
  */
 public abstract class SpokestackAdapter implements
       Callback<NLUResult>,
+      DialogueListener,
       OnSpeechEventListener,
       TraceListener,
       TTSListener {
@@ -154,6 +157,14 @@ public abstract class SpokestackAdapter implements
      * @param event The event from the TTS module.
      */
     public void ttsEvent(@NotNull TTSEvent event) {
+    }
+
+    /**
+     * Receive events from the dialogue management module.
+     * @param event The dialogue event.
+     */
+    @Override
+    public void onDialogueEvent(@NotNull DialogueEvent event) {
     }
 
     /**

--- a/src/main/java/io/spokestack/spokestack/dialogue/DialogueDispatcher.java
+++ b/src/main/java/io/spokestack/spokestack/dialogue/DialogueDispatcher.java
@@ -35,4 +35,22 @@ public final class DialogueDispatcher extends EventTracer {
             listener.onDialogueEvent(event);
         }
     }
+
+    /**
+     * Add a new listener to receive events from the dispatcher.
+     *
+     * @param listener The listener to add.
+     */
+    public void addListener(DialogueListener listener) {
+        this.listeners.add(listener);
+    }
+
+    /**
+     * Remove a dialogue listener, allowing it to be garbage collected.
+     *
+     * @param listener The listener to remove.
+     */
+    public void removeListener(DialogueListener listener) {
+        this.listeners.remove(listener);
+    }
 }

--- a/src/main/java/io/spokestack/spokestack/dialogue/DialogueManager.java
+++ b/src/main/java/io/spokestack/spokestack/dialogue/DialogueManager.java
@@ -28,10 +28,11 @@ import java.util.List;
  * In order to translate between NLU results and dynamic app actions, the
  * manager relies on a <i>dialogue policy</i>. An app may use Spokestack's
  * rule-based policy by providing the path to a JSON file describing the
- * policy's configuration under the {@code "policy-file"} configuration key, or
- * may use a different/custom policy by passing its class name under the {@code
- * "policy-class"} key. The class specified by the latter key must contain a
- * single-argument constructor that accepts a {@link SpeechConfig} instance.
+ * policy's configuration under the {@code "dialogue-policy-file"} configuration
+ * key, or may use a different/custom policy by passing its class name under the
+ * {@code "dialogue-policy-class"} key. The class specified by the latter key
+ * must contain a single-argument constructor that accepts a {@link
+ * SpeechConfig} instance.
  * </p>
  *
  * <p>
@@ -72,7 +73,7 @@ public final class DialogueManager implements Callback<NLUResult> {
     private DialoguePolicy buildPolicy(Builder builder) throws Exception {
         String defaultPolicy = RuleBasedDialoguePolicy.class.getName();
         String policyClass =
-              builder.config.getString("policy-class", defaultPolicy);
+              builder.config.getString("dialogue-policy-class", defaultPolicy);
 
         Object constructed;
         try {
@@ -241,7 +242,7 @@ public final class DialogueManager implements Callback<NLUResult> {
          * policy for the manager to use.
          *
          * <p>
-         * This is a convenience method for {@code setProperty("policy-file",
+         * This is a convenience method for {@code setProperty("dialogue-policy-file",
          * file)}.
          * </p>
          *
@@ -249,7 +250,7 @@ public final class DialogueManager implements Callback<NLUResult> {
          * @return the updated builder state
          */
         public Builder withPolicyFile(String file) {
-            setProperty("policy-file", file);
+            setProperty("dialogue-policy-file", file);
             return this;
         }
 
@@ -257,7 +258,7 @@ public final class DialogueManager implements Callback<NLUResult> {
          * Specify the dialogue policy for the manager to use.
          *
          * <p>
-         * This is a convenience method for {@code setProperty("policy-class",
+         * This is a convenience method for {@code setProperty("dialogue-policy-class",
          * file)}.
          * </p>
          *
@@ -266,7 +267,7 @@ public final class DialogueManager implements Callback<NLUResult> {
          * @return the updated builder state
          */
         public Builder withDialoguePolicy(String policyClass) {
-            setProperty("policy-class", policyClass);
+            setProperty("dialogue-policy-class", policyClass);
             return this;
         }
 
@@ -311,6 +312,9 @@ public final class DialogueManager implements Callback<NLUResult> {
          * @throws Exception if there is an error building the manager.
          */
         public DialogueManager build() throws Exception {
+            if (this.config.containsKey("trace-level")) {
+                withTraceLevel(this.config.getInteger("trace-level"));
+            }
             return new DialogueManager(this);
         }
     }

--- a/src/main/java/io/spokestack/spokestack/dialogue/DialogueManager.java
+++ b/src/main/java/io/spokestack/spokestack/dialogue/DialogueManager.java
@@ -1,11 +1,13 @@
 package io.spokestack.spokestack.dialogue;
 
 import androidx.annotation.NonNull;
+import io.spokestack.spokestack.SpeechConfig;
 import io.spokestack.spokestack.dialogue.policy.RuleBasedDialoguePolicy;
 import io.spokestack.spokestack.nlu.NLUResult;
 import io.spokestack.spokestack.util.Callback;
 import io.spokestack.spokestack.util.EventTracer;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -26,13 +28,14 @@ import java.util.List;
  * In order to translate between NLU results and dynamic app actions, the
  * manager relies on a <i>dialogue policy</i>. An app may use Spokestack's
  * rule-based policy by providing the path to a JSON file describing the
- * policy's configuration at build time, or a custom policy may be provided by
- * implementing {@link DialoguePolicy} and passing an instance of the
- * implementing class to the manager's builder.
+ * policy's configuration under the {@code "policy-file"} configuration key, or
+ * may use a different/custom policy by passing its class name under the {@code
+ * "policy-class"} key. The class specified by the latter key must contain a
+ * single-argument constructor that accepts a {@link SpeechConfig} instance.
  * </p>
  *
  * <p>
- * Dialogue management, like other Spokestack subsystems, is event-driven.
+ * Dialogue management, like other Spokestack modules, is event-driven.
  * Registered listeners will receive {@link DialogueEvent DialogueEvents} when
  * the system should make a change based on the user's last request. Events
  * include changes to the app's visual context, prompts to be read or displayed
@@ -48,18 +51,15 @@ public final class DialogueManager implements Callback<NLUResult> {
      */
     public static final String SLOT_PREFIX = "_";
 
-    private final DialoguePolicy policy;
     private final ConversationData dataStore;
     private final DialogueDispatcher eventDispatcher;
+
+    final DialoguePolicy policy;
 
     private NLUResult lastTurn;
 
     private DialogueManager(Builder builder) throws Exception {
-        if (builder.policyFile != null) {
-            this.policy = new RuleBasedDialoguePolicy(builder.policyFile);
-        } else {
-            this.policy = builder.dialoguePolicy;
-        }
+        this.policy = buildPolicy(builder);
         if (builder.conversationData != null) {
             this.dataStore = builder.conversationData;
         } else {
@@ -67,6 +67,23 @@ public final class DialogueManager implements Callback<NLUResult> {
         }
         this.eventDispatcher =
               new DialogueDispatcher(builder.traceLevel, builder.listeners);
+    }
+
+    private DialoguePolicy buildPolicy(Builder builder) throws Exception {
+        String defaultPolicy = RuleBasedDialoguePolicy.class.getName();
+        String policyClass =
+              builder.config.getString("policy-class", defaultPolicy);
+
+        Object constructed;
+        try {
+            constructed = Class
+                  .forName(policyClass)
+                  .getConstructor(SpeechConfig.class)
+                  .newInstance(builder.config);
+        } catch (InvocationTargetException e) {
+            throw (Exception) e.getCause();
+        }
+        return (DialoguePolicy) constructed;
     }
 
     /**
@@ -99,6 +116,7 @@ public final class DialogueManager implements Callback<NLUResult> {
 
     /**
      * Get the last user turn processed by the dialogue manager.
+     *
      * @return The last user turn processed by the dialogue manager.
      */
     public NLUResult getLastTurn() {
@@ -159,36 +177,96 @@ public final class DialogueManager implements Callback<NLUResult> {
     }
 
     /**
+     * Add a new listener to receive events from the dialogue management
+     * module.
+     *
+     * @param listener The listener to add.
+     */
+    public void addListener(DialogueListener listener) {
+        this.eventDispatcher.addListener(listener);
+    }
+
+    /**
+     * Remove a dialogue listener, allowing it to be garbage collected.
+     *
+     * @param listener The listener to remove.
+     */
+    public void removeListener(DialogueListener listener) {
+        this.eventDispatcher.removeListener(listener);
+    }
+
+    /**
      * Dialogue manager builder API.
      */
     public static class Builder {
 
-        private String policyFile;
-        private DialoguePolicy dialoguePolicy;
+        private final SpeechConfig config;
+        private final List<DialogueListener> listeners = new ArrayList<>();
+
         private ConversationData conversationData;
         private int traceLevel;
-        private final List<DialogueListener> listeners = new ArrayList<>();
+
+        /**
+         * Create a new dialogue manager builder with a default configuration.
+         */
+        public Builder() {
+            this(new SpeechConfig());
+        }
+
+        /**
+         * Create a new dialogue manager builder with the supplied
+         * configuration.
+         *
+         * @param speechConfig The configuration to use for dialogue
+         *                     management.
+         */
+        public Builder(SpeechConfig speechConfig) {
+            this.config = speechConfig;
+        }
+
+        /**
+         * Sets a configuration value.
+         *
+         * @param key   configuration property name
+         * @param value property value
+         * @return the updated builder state
+         */
+        public Builder setProperty(String key, Object value) {
+            this.config.put(key, value);
+            return this;
+        }
 
         /**
          * Specify the path to the JSON file containing a Spokestack dialogue
          * policy for the manager to use.
          *
+         * <p>
+         * This is a convenience method for {@code setProperty("policy-file",
+         * file)}.
+         * </p>
+         *
          * @param file Path to a dialogue configuration file.
          * @return the updated builder state
          */
         public Builder withPolicyFile(String file) {
-            this.policyFile = file;
+            setProperty("policy-file", file);
             return this;
         }
 
         /**
          * Specify the dialogue policy for the manager to use.
          *
-         * @param policy The dialogue policy to follow for user interactions.
+         * <p>
+         * This is a convenience method for {@code setProperty("policy-class",
+         * file)}.
+         * </p>
+         *
+         * @param policyClass The name of the class containing the dialogue
+         *                    policy to use.
          * @return the updated builder state
          */
-        public Builder withCustomPolicy(DialoguePolicy policy) {
-            this.dialoguePolicy = policy;
+        public Builder withDialoguePolicy(String policyClass) {
+            setProperty("policy-class", policyClass);
             return this;
         }
 
@@ -233,12 +311,7 @@ public final class DialogueManager implements Callback<NLUResult> {
          * @throws Exception if there is an error building the manager.
          */
         public DialogueManager build() throws Exception {
-            if (this.policyFile == null ^ this.dialoguePolicy == null) {
-                return new DialogueManager(this);
-            }
-            throw new IllegalArgumentException("dialogue manager requires "
-                  + "either a policy file or custom policy, but cannot "
-                  + "have both");
+            return new DialogueManager(this);
         }
     }
 }

--- a/src/main/java/io/spokestack/spokestack/dialogue/DialoguePolicy.java
+++ b/src/main/java/io/spokestack/spokestack/dialogue/DialoguePolicy.java
@@ -10,8 +10,9 @@ import io.spokestack.spokestack.nlu.NLUResult;
  * </p>
  *
  * <p>
- * A dialogue policy must have a no-argument constructor to be used by the
- * dialogue management system.
+ * A dialogue policy must have a constructor that accepts a {@link
+ * io.spokestack.spokestack.SpeechConfig} instance to be used by the dialogue
+ * management system.
  * </p>
  */
 public interface DialoguePolicy {

--- a/src/main/java/io/spokestack/spokestack/dialogue/policy/RuleBasedDialoguePolicy.java
+++ b/src/main/java/io/spokestack/spokestack/dialogue/policy/RuleBasedDialoguePolicy.java
@@ -57,7 +57,7 @@ import static io.spokestack.spokestack.dialogue.policy.Model.*;
  * </p>
  * <ul>
  *   <li>
- *      <b>policy-file</b> (string, required): file system path to the dialogue
+ *      <b>dialogue-policy-file</b> (string, required): file system path to the dialogue
  *      policy configuration.
  *   </li>
  * </ul>
@@ -81,7 +81,7 @@ public class RuleBasedDialoguePolicy implements DialoguePolicy {
      */
     public RuleBasedDialoguePolicy(SpeechConfig config)
           throws IOException, MalformedJsonException {
-        String policyFile = config.getString("policy-file");
+        String policyFile = config.getString("dialogue-policy-file");
         this.gson = new GsonBuilder()
               .disableHtmlEscaping()
               .create();

--- a/src/main/java/io/spokestack/spokestack/dialogue/policy/RuleBasedDialoguePolicy.java
+++ b/src/main/java/io/spokestack/spokestack/dialogue/policy/RuleBasedDialoguePolicy.java
@@ -3,6 +3,7 @@ package io.spokestack.spokestack.dialogue.policy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.stream.MalformedJsonException;
+import io.spokestack.spokestack.SpeechConfig;
 import io.spokestack.spokestack.dialogue.ConversationData;
 import io.spokestack.spokestack.dialogue.ConversationState;
 import io.spokestack.spokestack.dialogue.DialogueDispatcher;
@@ -50,6 +51,16 @@ import static io.spokestack.spokestack.dialogue.policy.Model.*;
  * on the dialogue manager in use so that any follow-up navigation/prompts can
  * occur.
  * </p>
+ *
+ * <p>
+ * This component supports the following configuration properties:
+ * </p>
+ * <ul>
+ *   <li>
+ *      <b>policy-file</b> (string, required): file system path to the dialogue
+ *      policy configuration.
+ *   </li>
+ * </ul>
  */
 public class RuleBasedDialoguePolicy implements DialoguePolicy {
     static final String STATE_KEY =
@@ -61,15 +72,16 @@ public class RuleBasedDialoguePolicy implements DialoguePolicy {
     private PendingTurn pendingTurn;
 
     /**
-     * Creates a dialogue policy from the supplied file.
+     * Creates a dialogue policy from the supplied configuration.
      *
-     * @param policyFile Path to a JSON configuration for the dialogue.
+     * @param config Configuration containing the path to a policy file.
      * @throws IOException            if there is an error reading the policy
      *                                file.
      * @throws MalformedJsonException if the policy file contains invalid JSON.
      */
-    public RuleBasedDialoguePolicy(String policyFile)
+    public RuleBasedDialoguePolicy(SpeechConfig config)
           throws IOException, MalformedJsonException {
+        String policyFile = config.getString("policy-file");
         this.gson = new GsonBuilder()
               .disableHtmlEscaping()
               .create();

--- a/src/test/java/io/spokestack/spokestack/dialogue/policy/DialoguePolicyTest.java
+++ b/src/test/java/io/spokestack/spokestack/dialogue/policy/DialoguePolicyTest.java
@@ -1,6 +1,7 @@
 package io.spokestack.spokestack.dialogue.policy;
 
 import androidx.annotation.NonNull;
+import io.spokestack.spokestack.SpeechConfig;
 import io.spokestack.spokestack.dialogue.ConversationData;
 import io.spokestack.spokestack.dialogue.DialogueDispatcher;
 import io.spokestack.spokestack.dialogue.DialogueEvent;
@@ -78,12 +79,16 @@ public final class DialoguePolicyTest {
           Collections.singletonList(LISTENER));
     private static ConversationData DATA = new InMemoryConversationData();
     private static RuleBasedDialoguePolicy POLICY;
-    private static String POLICY_FILE;
+    private static SpeechConfig SPEECH_CONFIG;
 
     public static void setPolicy(String policyFile)
           throws IOException {
-        POLICY_FILE = policyFile;
-        POLICY = new RuleBasedDialoguePolicy(policyFile);
+        if (SPEECH_CONFIG == null) {
+            SPEECH_CONFIG = new SpeechConfig();
+        }
+
+        SPEECH_CONFIG.put("policy-file", policyFile);
+        POLICY = new RuleBasedDialoguePolicy(SPEECH_CONFIG);
         clearPolicyState();
     }
 
@@ -123,7 +128,7 @@ public final class DialoguePolicyTest {
 
     public static void clearPolicyState() throws IOException {
         DATA = new InMemoryConversationData();
-        POLICY = new RuleBasedDialoguePolicy(POLICY_FILE);
+        POLICY = new RuleBasedDialoguePolicy(SPEECH_CONFIG);
         clearEvents();
     }
 

--- a/src/test/java/io/spokestack/spokestack/dialogue/policy/DialoguePolicyTest.java
+++ b/src/test/java/io/spokestack/spokestack/dialogue/policy/DialoguePolicyTest.java
@@ -87,7 +87,7 @@ public final class DialoguePolicyTest {
             SPEECH_CONFIG = new SpeechConfig();
         }
 
-        SPEECH_CONFIG.put("policy-file", policyFile);
+        SPEECH_CONFIG.put("dialogue-policy-file", policyFile);
         POLICY = new RuleBasedDialoguePolicy(SPEECH_CONFIG);
         clearPolicyState();
     }


### PR DESCRIPTION
These changes update the dialogue manager to be more pluggable like other Spokestack components. The rule-based policy is the default, but another policy can be specified by class name.

In addition, dialogue management is included in the Spokestack wrapper class but is disabled by default. I intend to leave this an undocumented feature for now in anticipation of updates to its design/API, but these changes will support a smooth release, and there are other changes/pending changes on master that need to go out in a release.