### PR TITLE
fix: timeout event when no keyword is recognized

### DIFF
--- a/src/main/java/io/spokestack/spokestack/asr/KeywordRecognizer.java
+++ b/src/main/java/io/spokestack/spokestack/asr/KeywordRecognizer.java
@@ -429,16 +429,15 @@ public final class KeywordRecognizer implements SpeechProcessor {
 
         context.traceInfo("keyword: %.3f %s", confidence, transcript);
 
-        // if we are under threshold, return the null class
-        if (confidence < this.threshold) {
-            transcript = "";
-            confidence = 1.0f - confidence;
+        if (confidence >= this.threshold) {
+            // raise the speech recognition event with the class transcript
+            context.setTranscript(transcript);
+            context.setConfidence(confidence);
+            context.dispatch(SpeechContext.Event.RECOGNIZE);
+        } else {
+            // if we are under threshold, time out without recognition
+            context.dispatch(SpeechContext.Event.TIMEOUT);
         }
-
-        // raise the speech recognition event with the class transcript
-        context.setTranscript(transcript);
-        context.setConfidence(confidence);
-        context.dispatch(SpeechContext.Event.RECOGNIZE);
 
         reset();
     }

--- a/src/test/java/io/spokestack/spokestack/asr/KeywordRecognizerTest.java
+++ b/src/test/java/io/spokestack/spokestack/asr/KeywordRecognizerTest.java
@@ -111,7 +111,7 @@ public class KeywordRecognizerTest {
 
     @Test
     public void testRecNullCtxDeactivate() throws Exception {
-        // verify that the null transcript is raised for the null class
+        // verify that a timeout is raised for the null class
         TestEnv env = new TestEnv(testConfig());
 
         env.context.setActive(true);
@@ -120,7 +120,7 @@ public class KeywordRecognizerTest {
         env.context.setActive(false);
         env.process();
 
-        assertEquals(SpeechContext.Event.RECOGNIZE, env.event);
+        assertEquals(SpeechContext.Event.TIMEOUT, env.event);
         assertEquals("", env.context.getTranscript());
     }
 


### PR DESCRIPTION
This change adjusts the KeywordRecognizer to raise a timeout
event when no keyword has been recognized instead of sending
an empty transcript, which brings its behavior in line with other
speech recognizer components.