### PR TITLE
NLU module updates, threaded through the `Spokestack` wrapper

### DIFF
--- a/src/main/java/io/spokestack/spokestack/nlu/NLUManager.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/NLUManager.java
@@ -63,6 +63,15 @@ public final class NLUManager implements AutoCloseable {
     }
 
     /**
+     * Get the NLU service currently in use.
+     *
+     * @return The current NLU service.
+     */
+    public NLUService getNlu() {
+        return nlu;
+    }
+
+    /**
      * Releases resources in use by the NLU module.
      */
     @Override

--- a/src/main/java/io/spokestack/spokestack/nlu/NLUService.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/NLUService.java
@@ -12,7 +12,7 @@ import io.spokestack.spokestack.util.AsyncResult;
  * and {@link NLUContext}.
  * </p>
  */
-public interface NLUService {
+public interface NLUService extends AutoCloseable {
 
     /**
      * Classifies a user utterance. Classification should be performed on a

--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TensorflowNLU.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/TensorflowNLU.java
@@ -212,6 +212,15 @@ public final class TensorflowNLU implements NLUService {
         return this.maxTokens;
     }
 
+    @Override
+    public void close() throws Exception {
+        this.executor.shutdownNow();
+        this.nluModel.close();
+        this.nluModel = null;
+        this.textEncoder = null;
+        this.outputParser = null;
+    }
+
     /**
      * Classify a user utterance, returning a wrapper that can either block
      * until the classification is complete or call a registered callback when

--- a/src/main/java/io/spokestack/spokestack/tts/TTSManager.java
+++ b/src/main/java/io/spokestack/spokestack/tts/TTSManager.java
@@ -101,6 +101,9 @@ public final class TTSManager implements AutoCloseable {
      * @param request The synthesis request data.
      */
     public void synthesize(SynthesisRequest request) {
+        if (this.ttsService == null) {
+            throw new IllegalStateException("TTS closed; call prepare()");
+        }
         this.ttsService.synthesize(request);
     }
 
@@ -159,9 +162,7 @@ public final class TTSManager implements AutoCloseable {
     @Override
     public void close() {
         release();
-        this.ttsService = null;
         this.output = null;
-        this.listeners.clear();
     }
 
     /**

--- a/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
+++ b/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
@@ -12,6 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.jupiter.api.function.Executable;
 import static org.junit.jupiter.api.Assertions.*;
+import static io.spokestack.spokestack.SpeechTestUtils.FreeInput;
 
 public class SpeechPipelineTest implements OnSpeechEventListener {
     private static final List<Class<?>> PROFILES = Arrays.asList(
@@ -160,6 +161,41 @@ public class SpeechPipelineTest implements OnSpeechEventListener {
         assertFalse(pipeline.getContext().isActive());
         assertEquals(-1, Input.counter);
         assertFalse(Stage.open);
+    }
+
+    @Test
+    public void testPause() throws Exception {
+        final SpeechPipeline pipeline = new SpeechPipeline.Builder()
+              .setInputClass("io.spokestack.spokestack.SpeechTestUtils$FreeInput")
+              .setProperty("sample-rate", 16000)
+              .setProperty("frame-width", 20)
+              .setProperty("buffer-width", 300)
+              .setProperty("trace-level", EventTracer.Level.DEBUG.value())
+              .build();
+
+        // startup
+        int frames = FreeInput.counter;
+        assertEquals(frames, 0);
+        pipeline.start();
+        assertTrue(pipeline.isRunning());
+        Thread.sleep(5);
+        assertTrue(FreeInput.counter > frames);
+
+        // we won't get any more frames if we're paused
+        pipeline.pause();
+
+        // wait for the pause to take effect
+        Thread.sleep(10);
+        frames = FreeInput.counter;
+
+        // wait some more to make sure we don't get any more frames
+        Thread.sleep(15);
+        assertEquals(FreeInput.counter, frames);
+
+        // after resuming, frames should start increasing almost immediately
+        pipeline.resume();
+        Thread.sleep(5);
+        assertTrue(FreeInput.counter > frames);
     }
 
     @Test

--- a/src/test/java/io/spokestack/spokestack/SpeechTestUtils.java
+++ b/src/test/java/io/spokestack/spokestack/SpeechTestUtils.java
@@ -1,0 +1,26 @@
+package io.spokestack.spokestack;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Test classes related to the speech pipeline used in more than one test
+ * suite.
+ */
+public class SpeechTestUtils {
+
+    public static class FreeInput implements SpeechInput {
+        public static int counter;
+
+        public FreeInput(SpeechConfig config) {
+            counter = 0;
+        }
+
+        public void close() {
+            counter = -1;
+        }
+
+        public void read(SpeechContext context, ByteBuffer frame) {
+            frame.putInt(0, ++counter);
+        }
+    }
+}

--- a/src/test/java/io/spokestack/spokestack/SpokestackTest.java
+++ b/src/test/java/io/spokestack/spokestack/SpokestackTest.java
@@ -16,6 +16,7 @@ import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -23,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static io.spokestack.spokestack.SpeechTestUtils.FreeInput;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({SystemClock.class})
@@ -285,7 +287,7 @@ public class SpokestackTest {
     }
 
     @Test
-    public void testClose() throws Exception {
+    public void testRestart() throws Exception {
         mockStatic(SystemClock.class);
         TestAdapter listener = new TestAdapter();
 
@@ -305,8 +307,8 @@ public class SpokestackTest {
               listener.speechEvents.poll(1, TimeUnit.SECONDS);
         assertEquals(SpeechContext.Event.ACTIVATE, event);
 
-        // modules don't work after close()
-        spokestack.close();
+        // modules don't work after stop()
+        spokestack.stop();
         assertNull(spokestack.getTts().getTtsService());
         assertNull(spokestack.getNlu().getNlu());
         assertThrows(
@@ -319,11 +321,51 @@ public class SpokestackTest {
               () -> spokestack.synthesize(request));
 
         // restart supported
-        spokestack.prepare();
+        spokestack.start();
         assertNotNull(spokestack.getTts().getTtsService());
         assertNotNull(spokestack.getNlu().getNlu());
         assertDoesNotThrow(() -> spokestack.classify("test"));
         assertDoesNotThrow(() -> spokestack.synthesize(request));
+    }
+
+    @Test
+    public void testPause() throws Exception {
+        mockStatic(SystemClock.class);
+        TestAdapter listener = new TestAdapter();
+
+        Spokestack.Builder builder = new Spokestack
+              .Builder(new SpeechPipeline.Builder(), mockTts())
+              .withoutWakeword()
+              .setConfig(testConfig())
+              .addListener(listener);
+
+        builder = mockAndroidComponents(builder);
+        builder.getPipelineBuilder()
+              .setInputClass("io.spokestack.spokestack.SpeechTestUtils$FreeInput");
+        Spokestack spokestack = new Spokestack(builder, mockNlu());
+
+        // startup
+        int frames = FreeInput.counter;
+        assertEquals(frames, 0);
+        spokestack.start();
+        Thread.sleep(10);
+        assertTrue(FreeInput.counter > frames);
+
+        // we won't get any more frames if we're paused
+        spokestack.pause();
+
+        // wait for the pause to take effect
+        Thread.sleep(10);
+        frames = FreeInput.counter;
+
+        // wait some more to make sure we don't get any more frames
+        Thread.sleep(15);
+        assertEquals(FreeInput.counter, frames);
+
+        // after resuming, frames should start increasing almost immediately
+        spokestack.resume();
+        Thread.sleep(5);
+        assertTrue(FreeInput.counter > frames);
     }
 
     private NLUManager mockNlu() throws Exception {

--- a/src/test/java/io/spokestack/spokestack/SpokestackTest.java
+++ b/src/test/java/io/spokestack/spokestack/SpokestackTest.java
@@ -308,6 +308,7 @@ public class SpokestackTest {
         // modules don't work after close()
         spokestack.close();
         assertNull(spokestack.getTts().getTtsService());
+        assertNull(spokestack.getNlu().getNlu());
         assertThrows(
               IllegalStateException.class,
               () -> spokestack.classify("test"));
@@ -320,6 +321,7 @@ public class SpokestackTest {
         // restart supported
         spokestack.prepare();
         assertNotNull(spokestack.getTts().getTtsService());
+        assertNotNull(spokestack.getNlu().getNlu());
         assertDoesNotThrow(() -> spokestack.classify("test"));
         assertDoesNotThrow(() -> spokestack.synthesize(request));
     }

--- a/src/test/java/io/spokestack/spokestack/nlu/tensorflow/NLUTestUtils.java
+++ b/src/test/java/io/spokestack/spokestack/nlu/tensorflow/NLUTestUtils.java
@@ -163,5 +163,8 @@ public class NLUTestUtils {
             return result;
         }
 
+        @Override
+        public void close() {
+        }
     }
 }


### PR DESCRIPTION
 I'd like an API sanity check here—see if the commit message pasted below makes sense. Further explanation: I think we need to keep `Spokestack.start()` and `stop()` limited to interacting with the speech pipeline—a user might want to force the pipeline to stop listening while playing a TTS prompt, so `stop()` can't call `close()` on TTS—but it would also be good to have the ability to fully release all modules' resources if necessary. 

Would it be less surprising if `start()` also ran `prepare()` implicitly?


---

This change makes the NLUService extend AutoCloseable, which forces a
`close()` method on all implementors. The existing service uses this to
release TensorFlow model and vocab resources.

On the NLU manager, `close()` has been duplicated as a convenience
method called `release()`, named for parallelism with the newly
added `prepare()` method, which is its inverse.

The NLU module was the last one to provide release/prepare
support, so adding it suggests a change to the Spokestack wrapper
API, removing the release/prepare methods used for the TTS module
and repurposing them to handle resources for both NLU and TTS.