### PR TITLE
breaking: TTS no longer responds to lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ dependencies {
     implementation 'org.tensorflow:tensorflow-lite:2.3.0'
 
     // for automatic playback of TTS audio
-    implementation 'androidx.lifecycle:lifecycle-common-java8:2.1.0'
     implementation 'androidx.media:media:1.2.0'
     implementation 'com.google.android.exoplayer:exoplayer-core:2.11.7'
 }
@@ -85,9 +84,8 @@ spokestack = Spokestack.Builder()
     .setProperty("wordpiece-vocab-path", "$cacheDir/vocab.txt")
     .setProperty("spokestack-id", "your-client-id")
     .setProperty("spokestack-secret", "your-secret-key")
-    // `applicationContext` and `lifecycle` are available inside all `Activity`s
+    // `applicationContext` is available inside all `Activity`s
     .withAndroidContext(applicationContext)
-    .withLifecycle(lifecycle)
     // see below; `listener` here inherits from `SpokestackAdapter`
     .addListener(listener)
     .build()

--- a/pom.xml
+++ b/pom.xml
@@ -82,12 +82,6 @@
          <scope>provided</scope>
       </dependency>
       <dependency>
-         <groupId>androidx.lifecycle</groupId>
-         <artifactId>lifecycle-common-java8</artifactId>
-         <version>2.1.0</version>
-         <scope>provided</scope>
-      </dependency>
-      <dependency>
          <groupId>androidx.media</groupId>
          <artifactId>media</artifactId>
          <version>1.1.0</version>

--- a/src/main/java/io/spokestack/spokestack/SpeechOutput.java
+++ b/src/main/java/io/spokestack/spokestack/SpeechOutput.java
@@ -2,7 +2,6 @@ package io.spokestack.spokestack;
 
 import android.content.Context;
 import androidx.annotation.NonNull;
-import androidx.lifecycle.LifecycleObserver;
 import io.spokestack.spokestack.tts.AudioResponse;
 import io.spokestack.spokestack.tts.TTSComponent;
 import io.spokestack.spokestack.tts.TTSEvent;
@@ -36,7 +35,7 @@ import io.spokestack.spokestack.tts.TTSListener;
  * @see TTSComponent
  */
 public abstract class SpeechOutput extends TTSComponent
-      implements AutoCloseable, LifecycleObserver, TTSListener {
+      implements AutoCloseable, TTSListener {
 
     @Override
     public void eventReceived(@NonNull TTSEvent event) {

--- a/src/main/java/io/spokestack/spokestack/Spokestack.java
+++ b/src/main/java/io/spokestack/spokestack/Spokestack.java
@@ -1,7 +1,6 @@
 package io.spokestack.spokestack;
 
 import android.content.Context;
-import androidx.lifecycle.Lifecycle;
 import io.spokestack.spokestack.dialogue.DialogueManager;
 import io.spokestack.spokestack.nlu.NLUManager;
 import io.spokestack.spokestack.nlu.NLUResult;
@@ -159,17 +158,6 @@ public final class Spokestack extends SpokestackAdapter
 
         if (this.tts != null) {
             this.tts.setAndroidContext(context);
-        }
-    }
-
-    /**
-     * Update the Android lifecycle used by the TTS manager.
-     *
-     * @param lifecycle The new Android lifecycle.
-     */
-    public void setAndroidLifecycle(Lifecycle lifecycle) {
-        if (this.tts != null) {
-            this.tts.registerLifecycle(lifecycle);
         }
     }
 
@@ -434,7 +422,6 @@ public final class Spokestack extends SpokestackAdapter
         private SpeechConfig speechConfig;
         private TranscriptEditor transcriptEditor;
         private Context appContext;
-        private Lifecycle appLifecycle;
 
         /**
          * Create a Spokestack builder with a default configuration. The speech
@@ -513,11 +500,6 @@ public final class Spokestack extends SpokestackAdapter
          *       {@link #withAndroidContext(android.content.Context)}:
          *       Android Application context used to manage the audio session
          *       for automatic playback.
-         *   </li>
-         *   <li>
-         *       {@link #withLifecycle(androidx.lifecycle.Lifecycle)}:
-         *       Android lifecycle context used to manage automatic pausing and
-         *       resuming of audio on application lifecycle events.
          *   </li>
          *   </ul>
          *     </li>
@@ -719,18 +701,6 @@ public final class Spokestack extends SpokestackAdapter
         }
 
         /**
-         * Sets the Android Lifecycle used for management of TTS playback.
-         *
-         * @param lifecycle the Android Lifecycle.
-         * @return the updated builder
-         */
-        public Builder withLifecycle(Lifecycle lifecycle) {
-            this.appLifecycle = lifecycle;
-            this.ttsBuilder.setLifecycle(lifecycle);
-            return this;
-        }
-
-        /**
          * Signal that Spokestack's speech pipeline should not be used to
          * recognize speech.
          *
@@ -843,11 +813,6 @@ public final class Spokestack extends SpokestackAdapter
                     throw new IllegalArgumentException("app context is "
                           + "required for playback management; see"
                           + "TTSManager.Builder.setAndroidContext()");
-                }
-                if (this.appLifecycle == null) {
-                    throw new IllegalArgumentException("app lifecycle is "
-                          + "required for playback management; see"
-                          + "TTSManager.Builder.setLifecycle()");
                 }
             }
             if (!this.speechConfig.containsKey("dialogue-policy-file")

--- a/src/main/java/io/spokestack/spokestack/tts/SpokestackTTSOutput.java
+++ b/src/main/java/io/spokestack/spokestack/tts/SpokestackTTSOutput.java
@@ -6,8 +6,6 @@ import android.net.Uri;
 import android.os.Build;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.lifecycle.DefaultLifecycleObserver;
-import androidx.lifecycle.LifecycleOwner;
 import androidx.media.AudioAttributesCompat;
 import androidx.media.AudioFocusRequestCompat;
 import androidx.media.AudioManagerCompat;
@@ -38,15 +36,10 @@ import org.jetbrains.annotations.NotNull;
  * <p>
  * The Spokestack audio player uses
  * <a href="https://exoplayer.dev/">ExoPlayer</a>
- * to handle automatic playback of TTS responses. It responds to events in the
- * Android component lifecycle, pausing and resuming itself along with its host
- * app's activities.
- * </p>
- *
- * <p>
- * Note that this audio player does not provide a UI. It is designed to be used
- * within a TTS subsystem controlled by a {@link TTSManager} in an app that
- * wants to delegate all media management to Spokestack; if fine control over
+ * to handle automatic playback of TTS responses. Note that it
+ * does not provide a UI. It is designed to be used within a TTS subsystem
+ * controlled by a {@link TTSManager} in an app that wants to delegate all
+ * media management to Spokestack; if fine control over
  * playback is desired, consider adding a {@link TTSListener} to the {@code
  * TTSManager} and managing audio via its methods.
  * </p>
@@ -61,7 +54,7 @@ import org.jetbrains.annotations.NotNull;
  */
 public class SpokestackTTSOutput extends SpeechOutput
       implements Player.EventListener,
-      AudioManager.OnAudioFocusChangeListener, DefaultLifecycleObserver {
+      AudioManager.OnAudioFocusChangeListener {
 
     private final int contentType;
     private final int usage;
@@ -269,23 +262,6 @@ public class SpokestackTTSOutput extends SpeechOutput
         }
     }
 
-    @Override
-    public void onResume(@NonNull LifecycleOwner owner) {
-        this.taskHandler.run(() -> {
-            if (mediaPlayer != null) {
-                // restore player state
-                mediaPlayer.seekTo(playerState.window,
-                      playerState.curPosition);
-            }
-        });
-        playContent();
-    }
-
-    @Override
-    public void onStop(@NonNull LifecycleOwner owner) {
-        pauseContent();
-    }
-
     /**
      * Start or resume playback of any TTS responses.
      */
@@ -395,18 +371,6 @@ public class SpokestackTTSOutput extends SpeechOutput
             return player;
         }
     }
-
-    // these lifecycle methods are unused but must be implemented to maintain
-    // backwards compatibility with older Android APIs that don't allow the
-    // default implementations in DefaultLifecycleObserver
-
-    @Override public void onCreate(@NonNull LifecycleOwner owner) { }
-
-    @Override public void onStart(@NonNull LifecycleOwner owner) { }
-
-    @Override public void onPause(@NonNull LifecycleOwner owner) { }
-
-    @Override public void onDestroy(@NonNull LifecycleOwner owner) { }
 
     // similarly, implementing these listener methods maintains backwards
     // compatibility for ExoPlayer

--- a/src/test/java/io/spokestack/spokestack/SpokestackTest.java
+++ b/src/test/java/io/spokestack/spokestack/SpokestackTest.java
@@ -2,8 +2,6 @@ package io.spokestack.spokestack;
 
 import android.content.Context;
 import android.os.SystemClock;
-import androidx.lifecycle.LifecycleOwner;
-import androidx.lifecycle.LifecycleRegistry;
 import io.spokestack.spokestack.nlu.NLUManager;
 import io.spokestack.spokestack.nlu.NLUResult;
 import io.spokestack.spokestack.nlu.tensorflow.NLUTestUtils;
@@ -38,13 +36,8 @@ public class SpokestackTest {
 
         Spokestack.Builder builder = new Spokestack.Builder();
 
-        // missing lifecycle
-        assertThrows(IllegalArgumentException.class,
-              () -> {
-                  builder
-                        .withAndroidContext(mock(Context.class))
-                        .build();
-              });
+        // missing context
+        assertThrows(IllegalArgumentException.class, builder::build);
 
         // TTS playback disabled
         // avoid creating a real websocket by also faking the service class
@@ -211,14 +204,11 @@ public class SpokestackTest {
 
         Spokestack spokestack = new Spokestack(builder, mockNlu());
 
-        // handle context/lifecycle separately to make sure the convenience
+        // handle context separately to make sure the convenience
         // methods work
         Context androidContext = mock(Context.class);
-        LifecycleRegistry lifecycleRegistry =
-              new LifecycleRegistry(mock(LifecycleOwner.class));
 
         spokestack.setAndroidContext(androidContext);
-        spokestack.setAndroidLifecycle(lifecycleRegistry);
 
         listener.setSpokestack(spokestack);
         TTSManager tts = spokestack.getTts();
@@ -314,12 +304,9 @@ public class SpokestackTest {
     private Spokestack.Builder mockAndroidComponents(
           Spokestack.Builder builder) {
         Context context = mock(Context.class);
-        LifecycleRegistry lifecycleRegistry =
-              new LifecycleRegistry(mock(LifecycleOwner.class));
 
         return builder
-              .withAndroidContext(context)
-              .withLifecycle(lifecycleRegistry);
+              .withAndroidContext(context);
     }
 
     private SpeechConfig testConfig() {

--- a/src/test/java/io/spokestack/spokestack/tts/SpokestackTTSOutputTest.java
+++ b/src/test/java/io/spokestack/spokestack/tts/SpokestackTTSOutputTest.java
@@ -6,9 +6,6 @@ import android.content.pm.PackageManager;
 import android.media.AudioManager;
 import android.net.Uri;
 import androidx.annotation.NonNull;
-import androidx.lifecycle.Lifecycle;
-import androidx.lifecycle.LifecycleOwner;
-import androidx.lifecycle.LifecycleRegistry;
 import com.google.android.exoplayer2.ExoPlaybackException;
 import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.PlaybackParameters;
@@ -21,7 +18,6 @@ import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -38,14 +34,6 @@ import static org.mockito.Mockito.*;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(ExoPlaybackException.class)
 public class SpokestackTTSOutputTest {
-
-    // to avoid a stubbed class error
-    @Mock
-    @SuppressWarnings("unused")
-    LifecycleOwner owner;
-
-    @InjectMocks
-    private LifecycleRegistry lifecycleRegistry;
 
     @Mock
     private Context mockContext;
@@ -89,27 +77,16 @@ public class SpokestackTTSOutputTest {
         SpokestackTTSOutput ttsOutput =
               new SpokestackTTSOutput(null, factory);
         ttsOutput.setAndroidContext(mockContext);
-        lifecycleRegistry.addObserver(ttsOutput);
         ttsOutput.prepare();
-        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
 
         ExoPlayer mediaPlayer = ttsOutput.getMediaPlayer();
         assertNotNull(mediaPlayer);
         // no content, so nothing to play
         assertFalse(mediaPlayer.getPlayWhenReady());
 
-        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
-        verify(mediaPlayer, times(1)).setPlayWhenReady(false);
-
         ttsOutput.close();
         mediaPlayer = ttsOutput.getMediaPlayer();
         assertNull(mediaPlayer);
-
-        // included for test coverage; these should not throw errors
-        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
-        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START);
-        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE);
-        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY);
     }
 
     @Test

--- a/src/test/java/io/spokestack/spokestack/tts/TTSTestUtils.java
+++ b/src/test/java/io/spokestack/spokestack/tts/TTSTestUtils.java
@@ -2,8 +2,6 @@ package io.spokestack.spokestack.tts;
 
 import android.content.Context;
 import android.net.Uri;
-import androidx.lifecycle.DefaultLifecycleObserver;
-import androidx.lifecycle.LifecycleOwner;
 import io.spokestack.spokestack.SpeechConfig;
 import io.spokestack.spokestack.SpeechOutput;
 import org.jetbrains.annotations.NotNull;
@@ -37,8 +35,7 @@ public class TTSTestUtils {
         }
     }
 
-    public static class Output extends SpeechOutput
-          implements DefaultLifecycleObserver {
+    public static class Output extends SpeechOutput {
 
         LinkedBlockingQueue<String> events;
 
@@ -53,14 +50,6 @@ public class TTSTestUtils {
 
         public LinkedBlockingQueue<String> getEvents() {
             return events;
-        }
-
-        @Override
-        public void onResume(@NotNull LifecycleOwner owner) {
-            // protect against multiple calls by the registry during tests
-            if (this.events.isEmpty()) {
-                this.events.add("onResume");
-            }
         }
 
         @Override


### PR DESCRIPTION
This change stops the built-in TTS player from observing and
responding to Android lifecycle events. An app with multiple
activities will want to decide for itself which events trigger
changes in the TTS system. The new default setting will allow
playback to continue across activity transitions if Spokestack
is established as a long-lived resource not tied to a single
activity/fragment.

Tested locally in a multi-activity app, and this version feels much less disruptive for the reason mentioned above.