### PR TITLE
fix: tighten task submission in TTS player

### DIFF
--- a/src/main/java/io/spokestack/spokestack/util/TaskHandler.java
+++ b/src/main/java/io/spokestack/spokestack/util/TaskHandler.java
@@ -14,7 +14,7 @@ public final class TaskHandler {
     /**
      * Initialize a new task handler.
      *
-     * @param runOnMainThread {@code true} if tasks submitted to this hanlder
+     * @param runOnMainThread {@code true} if tasks submitted to this handler
      *                        should run on the application's main {@code
      *                        Looper}.
      */


### PR DESCRIPTION
This change moves ExoPlayer preparation and content playing into
the same task when a new TTS URL is received, reducing the possibility
of a race condition in constructing the player when more than one TTS
response becomes available in quick succession.

Additionally, uses of `prepare` and `clear` on the internal media player
and media source have been consolidated to reduce churn.