### PR TITLE
fix: adjust surefire forking for CI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,8 @@
                <useSystemClassLoader>false</useSystemClassLoader>
                <argLine>${argLine} -Djava.library.path=./target -XX:-OmitStackTraceInFastThrow</argLine>
                <trimStackTrace>false</trimStackTrace>
+               <forkCount>4</forkCount>
+               <reuseForks>false</reuseForks>
             </configuration>
          </plugin>
 


### PR DESCRIPTION
This addresses intermittently failing builds at CircleCI by
altering how Maven generates forks for running tests. Values
were derived by trial and error on a Circle VM.