### PR TITLE
fix: thread cleanup in test suites

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,8 +260,6 @@
                <useSystemClassLoader>false</useSystemClassLoader>
                <argLine>${argLine} -Djava.library.path=./target -XX:-OmitStackTraceInFastThrow</argLine>
                <trimStackTrace>false</trimStackTrace>
-               <forkCount>4</forkCount>
-               <reuseForks>false</reuseForks>
             </configuration>
          </plugin>
 

--- a/src/main/java/io/spokestack/spokestack/SpeechPipeline.java
+++ b/src/main/java/io/spokestack/spokestack/SpeechPipeline.java
@@ -72,11 +72,11 @@ public final class SpeechPipeline implements AutoCloseable {
     private final List<String> stageClasses;
     private final SpeechConfig config;
     private final SpeechContext context;
+    private volatile boolean running;
+    private volatile boolean paused;
     private SpeechInput input;
     private List<SpeechProcessor> stages;
     private Thread thread;
-    private boolean running;
-    private boolean paused;
     private boolean managed;
 
     /**
@@ -227,7 +227,7 @@ public final class SpeechPipeline implements AutoCloseable {
     }
 
     private void startThread() throws Exception {
-        this.thread = new Thread(this::run);
+        this.thread = new Thread(this::run, "Spokestack-speech-pipeline");
         this.running = true;
         this.thread.start();
     }
@@ -299,6 +299,9 @@ public final class SpeechPipeline implements AutoCloseable {
             }
         } else {
             dispatch();
+        }
+        if (Thread.currentThread().isInterrupted()) {
+            this.running = false;
         }
     }
 

--- a/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
+++ b/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
@@ -8,6 +8,7 @@ import java.nio.ByteBuffer;
 import androidx.annotation.NonNull;
 import io.spokestack.spokestack.android.AudioRecordError;
 import io.spokestack.spokestack.util.EventTracer;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -35,6 +36,16 @@ public class SpeechPipelineTest implements OnSpeechEventListener {
     @Before
     public void before() {
         this.events.clear();
+    }
+
+    @After
+    public void after() {
+        // shut down any stray speech pipeline background threads
+        for (Thread thread : Thread.getAllStackTraces().keySet()) {
+            if (thread.getName().contains("Spokestack")) {
+                thread.interrupt();
+            }
+        }
     }
 
     @Test

--- a/src/test/java/io/spokestack/spokestack/SpokestackTest.java
+++ b/src/test/java/io/spokestack/spokestack/SpokestackTest.java
@@ -11,12 +11,12 @@ import io.spokestack.spokestack.tts.TTSManager;
 import io.spokestack.spokestack.tts.TTSTestUtils;
 import io.spokestack.spokestack.util.EventTracer;
 import org.jetbrains.annotations.NotNull;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -29,6 +29,16 @@ import static io.spokestack.spokestack.SpeechTestUtils.FreeInput;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({SystemClock.class})
 public class SpokestackTest {
+
+    @After
+    public void after() {
+        // shut down any stray speech pipeline background threads
+        for (Thread thread : Thread.getAllStackTraces().keySet()) {
+            if (thread.getName().contains("Spokestack")) {
+                thread.interrupt();
+            }
+        }
+    }
 
     @Test
     public void testBuild() throws Exception {


### PR DESCRIPTION
This is a more comprehensive fix to intermittent
failures at Circle, which persisted after the change
to maven-surefire forking.

Tests that use the full speech pipeline and its accompanying
background thread now automatically clean up that background
thread after the test. Inside the speech pipeline itself, the
background thread has been given a recognizable name and made
responsive to interruption. While this should not be a problem at
runtime under normal usage, the change dramatically reduces
memory usage during tests.