### PR TITLE
reduce keyword recognizer receptive field

### DIFF
--- a/src/main/java/io/spokestack/spokestack/asr/KeywordRecognizer.java
+++ b/src/main/java/io/spokestack/spokestack/asr/KeywordRecognizer.java
@@ -146,7 +146,7 @@ public final class KeywordRecognizer implements SpeechProcessor {
     /** default keyword-fft-hop-length configuration value. */
     public static final int DEFAULT_FFT_HOP_LENGTH = 10;
     /** default keyword-mel-frame-length configuration value. */
-    public static final int DEFAULT_MEL_FRAME_LENGTH = 1090;
+    public static final int DEFAULT_MEL_FRAME_LENGTH = 110;
     /** default keyword-mel-frame-width configuration value. */
     public static final int DEFAULT_MEL_FRAME_WIDTH = 40;
     /** default keyword-encode-length configuration value. */


### PR DESCRIPTION
Experiments have shown that replacing the matchboxnet frontend with a simple convolutional block significantly improves recognition performance, while also reducing the computational burden. Doing so reduces the default receptive field size from 109 frames to 11 frames, which should be used as the default going forward. Existing keyword models for google speech commands and mnist have been deployed for this change.

This change to the default should also be propagated to the ios library @noelweichbrodt.