### PR TITLE
fix typo in Spokestack ASR profile

### DIFF
--- a/src/main/java/io/spokestack/spokestack/profile/PushToTalkSpokestackASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/PushToTalkSpokestackASR.java
@@ -40,7 +40,7 @@ public class PushToTalkSpokestackASR implements PipelineProfile {
         stages.add("io.spokestack.spokestack.webrtc.VoiceActivityDetector");
         stages.add("io.spokestack.spokestack.ActivationTimeout");
         stages.add(
-              "io.spokestack.spokestack.android.SpokestackCloudRecognizer");
+              "io.spokestack.spokestack.asr.SpokestackCloudRecognizer");
 
         return builder
               .setInputClass("io.spokestack.spokestack.android.MicrophoneInput")


### PR DESCRIPTION
Fully qualified class names strike again—at least I came up with a better way to test them this time.