### PR TITLE
feat: convenience method to set pipeline profile

### DIFF
--- a/src/main/java/io/spokestack/spokestack/Spokestack.java
+++ b/src/main/java/io/spokestack/spokestack/Spokestack.java
@@ -698,6 +698,23 @@ public final class Spokestack extends SpokestackAdapter
         }
 
         /**
+         * Uses a {@link PipelineProfile} to configure the speech pipeline,
+         * returning the modified builder. Subsequent calls to {@code
+         * withPipelineProfile} or {@code setProperty} can override
+         * configuration set by a profile.
+         *
+         * @param profileClass class name of the profile to apply.
+         * @return the updated builder
+         * @throws IllegalArgumentException if the specified profile does not
+         *                                  exist
+         */
+        public Builder withPipelineProfile(String profileClass)
+              throws IllegalArgumentException {
+            this.pipelineBuilder.useProfile(profileClass);
+            return this;
+        }
+
+        /**
          * Sets a configuration value.
          *
          * @param key   Configuration property name
@@ -772,9 +789,7 @@ public final class Spokestack extends SpokestackAdapter
          * Signal that Spokestack's TensorFlow Lite wakeword detector should not
          * be used. This is equivalent to calling
          * <pre>
-         * builder
-         *     .getPipelineBuilder()
-         *     .useProfile(
+         * builder.withPipelineProfile(
          *         "io.spokestack.spokestack.profile.PushToTalkAndroidASR");
          * </pre>
          * <p>
@@ -787,8 +802,7 @@ public final class Spokestack extends SpokestackAdapter
         public Builder withoutWakeword() {
             String profileClass =
                   "io.spokestack.spokestack.profile.PushToTalkAndroidASR";
-            this.pipelineBuilder.useProfile(profileClass);
-            return this;
+            return this.withPipelineProfile(profileClass);
         }
 
         /**

--- a/src/test/java/io/spokestack/spokestack/SpokestackTest.java
+++ b/src/test/java/io/spokestack/spokestack/SpokestackTest.java
@@ -118,6 +118,17 @@ public class SpokestackTest {
     }
 
     @Test
+    public void testPipelineProfile() {
+        // this only tests that the convenience method properly dispatches to
+        // the pipeline version, failing with an invalid profile;
+        // the valid profiles are tested by the speech pipeline test
+        assertThrows(IllegalArgumentException.class, () ->
+              new Spokestack.Builder()
+                    .withPipelineProfile("io.spokestack.InvalidProfile")
+        );
+    }
+
+    @Test
     public void testNlu() throws Exception {
         TestAdapter listener = new TestAdapter();
 


### PR DESCRIPTION
In order to change the pipeline profile, users currently have to retrieve the pipeline builder and set the profile on _it_, which breaks the call chain of a `Spokestack` builder setup. This change makes it easier to switch from the platform default ASR to, for example, a keyword-based ASR.