### PR TITLE
feat: load keyword classes from metadata file

### DIFF
--- a/src/main/java/io/spokestack/spokestack/asr/KeywordMetadata.java
+++ b/src/main/java/io/spokestack/spokestack/asr/KeywordMetadata.java
@@ -1,0 +1,38 @@
+package io.spokestack.spokestack.asr;
+
+/**
+ * A schema class used for JSON metadata accompanying a keyword model. The only
+ * item of interest in the metadata is the list of classes recognized by the
+ * model.
+ */
+final class KeywordMetadata {
+    private final KeywordClass[] classes;
+
+    KeywordMetadata(KeywordClass[] classArr) {
+        this.classes = classArr;
+    }
+
+    /**
+     * @return the names of the classes associated with this model.
+     */
+    public String[] getClassNames() {
+        String[] classNames = new String[this.classes.length];
+        for (int i = 0; i < this.classes.length; i++) {
+            classNames[i] = this.classes[i].name;
+        }
+        return classNames;
+    }
+
+    /**
+     * A class of utterance recognized by a keyword model. It may contain many
+     * utterances, but only the top-level class name is of interest to the
+     * model.
+     */
+    static class KeywordClass {
+        private final String name;
+
+        KeywordClass(String className) {
+            this.name = className;
+        }
+    }
+}

--- a/src/test/resources/keyword.json
+++ b/src/test/resources/keyword.json
@@ -1,0 +1,21 @@
+{
+  "classes": [{
+    "name": "up",
+    "utterances": [{
+      "id": "3808cd80-9f1e-4336-afce-676c194f819a",
+      "text": "up"
+    }, {
+      "id": "18d8f641-6bf7-45b5-953b-c14086dd0768",
+      "text": "pup"
+    }]
+  }, {
+    "name": "down",
+    "utterances": [{
+      "id": "d368e2a8-1c8b-4c13-8ed8-03d98c5ee8cc",
+      "text": "down"
+    }]
+  }],
+  "name": "Test",
+  "type": "keyword",
+  "revision": "24d0c03a-13bf-40cc-86a3-bcc64d1b6004"
+}


### PR DESCRIPTION
This change allows keyword classes to be loaded from the model's metadata file, which makes specifying the classes less manual and prone to ordering errors.