### PR TITLE
Rasa Open Source integration

### DIFF
--- a/src/main/java/io/spokestack/spokestack/Spokestack.java
+++ b/src/main/java/io/spokestack/spokestack/Spokestack.java
@@ -8,6 +8,8 @@ import io.spokestack.spokestack.nlu.tensorflow.parsers.DigitsParser;
 import io.spokestack.spokestack.nlu.tensorflow.parsers.IdentityParser;
 import io.spokestack.spokestack.nlu.tensorflow.parsers.IntegerParser;
 import io.spokestack.spokestack.nlu.tensorflow.parsers.SelsetParser;
+import io.spokestack.spokestack.rasa.RasaOpenSourceNLU;
+import io.spokestack.spokestack.rasa.RasaDialoguePolicy;
 import io.spokestack.spokestack.tts.SynthesisRequest;
 import io.spokestack.spokestack.tts.TTSEvent;
 import io.spokestack.spokestack.tts.TTSManager;
@@ -518,6 +520,13 @@ public final class Spokestack extends SpokestackAdapter
          *     </li>
          *     <li>
          *         <b>NLU</b> (properties)
+         *         <p>
+         *         Note that NLU properties are not required if Rasa NLU and
+         *         dialogue management are in use
+         *         (see {@link #useRasaOpenSource(String)}),
+         *         but other properties are required to configure the Rasa
+         *         integration.
+         *         </p>
          *     <ul>
          *   <li>
          *      <b>nlu-model-path</b> (string): file system path to the NLU
@@ -575,6 +584,24 @@ public final class Spokestack extends SpokestackAdapter
          *   </li>
          *   <li>
          *      <b>dialogue-policy-class</b> (string): Class name of a custom dialogue
+         *      policy.
+         *   </li>
+         *   </ul>
+         *     </li>
+         *     <li>
+         *         <b>Dialogue Management</b> (properties)
+         *         <p>
+         *         Like NLU, these properties are not required if Rasa NLU and
+         *         dialogue management are in use via
+         *         {@link #useRasaOpenSource(String)}.
+         *         </p>
+         *     <ul>
+         *   <li>
+         *      <b>policy-file</b> (string): Path to a JSON file used to
+         *      configure the rule-based dialogue policy.
+         *   </li>
+         *   <li>
+         *      <b>policy-class</b> (string): Class name of a custom dialogue
          *      policy.
          *   </li>
          *   </ul>
@@ -727,6 +754,30 @@ public final class Spokestack extends SpokestackAdapter
         }
 
         /**
+         * Use the Rasa Open Source NLU and dialogue policy components to
+         * handle user utterances.
+         *
+         * <p>
+         * This method sets the {@code rasa-oss-url} property automatically;
+         * (see {@link RasaOpenSourceNLU}
+         * and {@link io.spokestack.spokestack.rasa.RasaDialoguePolicy} for
+         * other relevant properties).
+         * </p>
+         *
+         * @param rasaCoreUrl URL to the Rasa Open Source server.
+         *                    The Rasa Open Source component is designed to use
+         *                    Rasa's REST channel.
+         * @return the updated builder
+         */
+        public Builder useRasaOpenSource(String rasaCoreUrl) {
+            this.setProperty("rasa-oss-url", rasaCoreUrl);
+            this.nluBuilder.setServiceClass(RasaOpenSourceNLU.class.getName());
+            this.dialogueBuilder
+                  .withDialoguePolicy(RasaDialoguePolicy.class.getName());
+            return this;
+        }
+
+        /**
          * Sets a transcript editor used to alter ASR transcripts before they
          * are classified by the NLU module.
          *
@@ -847,6 +898,17 @@ public final class Spokestack extends SpokestackAdapter
          */
         public Builder withoutAutoPlayback() {
             this.useTTSPlayback = false;
+            return this;
+        }
+
+        /**
+         * Signal that Spokestack's dialogue management module should not be
+         * used.
+         *
+         * @return the updated builder
+         */
+        public Builder withoutDialogueManagement() {
+            this.useDialogue = false;
             return this;
         }
 

--- a/src/main/java/io/spokestack/spokestack/dialogue/DialogueManager.java
+++ b/src/main/java/io/spokestack/spokestack/dialogue/DialogueManager.java
@@ -242,8 +242,8 @@ public final class DialogueManager implements Callback<NLUResult> {
          * policy for the manager to use.
          *
          * <p>
-         * This is a convenience method for {@code setProperty("dialogue-policy-file",
-         * file)}.
+         * This is a convenience method for {@code
+         * setProperty("dialogue-policy-file", file)}.
          * </p>
          *
          * @param file Path to a dialogue configuration file.
@@ -258,8 +258,8 @@ public final class DialogueManager implements Callback<NLUResult> {
          * Specify the dialogue policy for the manager to use.
          *
          * <p>
-         * This is a convenience method for {@code setProperty("dialogue-policy-class",
-         * file)}.
+         * This is a convenience method for {@code
+         * setProperty("dialogue-policy-class", policyClass)}.
          * </p>
          *
          * @param policyClass The name of the class containing the dialogue

--- a/src/main/java/io/spokestack/spokestack/dialogue/DialogueManager.java
+++ b/src/main/java/io/spokestack/spokestack/dialogue/DialogueManager.java
@@ -134,6 +134,17 @@ public final class DialogueManager implements Callback<NLUResult> {
     }
 
     /**
+     * Finalize a prompt, interpolating template strings using the current
+     * conversation data store.
+     *
+     * @param prompt The prompt to be finalized.
+     * @return The finalized prompt.
+     */
+    public FinalizedPrompt finalizePrompt(Prompt prompt) {
+        return prompt.finalizePrompt(this.dataStore);
+    }
+
+    /**
      * Dump the dialogue policy's current state to the currently registered data
      * store. This can be used in conjunction with {@link #load(String) load()}
      * to resume a dialogue in progress in the next app session.
@@ -269,6 +280,15 @@ public final class DialogueManager implements Callback<NLUResult> {
         public Builder withDialoguePolicy(String policyClass) {
             setProperty("dialogue-policy-class", policyClass);
             return this;
+        }
+
+        /**
+         * @return whether this builder has a dialogue policy enabled via
+         * class or JSON file.
+         */
+        public boolean hasPolicy() {
+            return this.config.containsKey("dialogue-policy-file")
+                  || this.config.containsKey("dialogye-policy-class");
         }
 
         /**

--- a/src/main/java/io/spokestack/spokestack/dialogue/FinalizedPrompt.java
+++ b/src/main/java/io/spokestack/spokestack/dialogue/FinalizedPrompt.java
@@ -1,0 +1,169 @@
+package io.spokestack.spokestack.dialogue;
+
+import androidx.annotation.NonNull;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A finalized prompt contains the same fields as a {@link Prompt}, but instead
+ * of template placeholders, its contents are fully interpolated strings ready
+ * to be displayed to the user or synthesized by TTS.
+ */
+public final class FinalizedPrompt {
+    private final String id;
+    private final String text;
+    private final String voice;
+    private final Proposal proposal;
+    private final FinalizedPrompt[] reprompts;
+    private final boolean endsConversation;
+
+    private FinalizedPrompt(Builder builder) {
+        this.id = builder.id;
+        this.text = builder.text;
+        if (builder.voice == null) {
+            this.voice = builder.text;
+        } else {
+            this.voice = builder.voice;
+        }
+        this.proposal = builder.proposal;
+        this.reprompts = builder.reprompts;
+        this.endsConversation = builder.endsConversation;
+    }
+
+    /**
+     * @return The prompt's ID.
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Get a version of the prompt formatted for TTS synthesis.
+     *
+     * @return A version of the prompt formatted for TTS synthesis.
+     */
+    public String getVoice() {
+        return voice;
+    }
+
+    /**
+     * Get a version of the prompt formatted for print.
+     *
+     * @return A version of the prompt formatted for print.
+     */
+    public String getText() {
+        return text;
+    }
+
+    /**
+     * @return this prompt's proposal.
+     */
+    public Proposal getProposal() {
+        return proposal;
+    }
+
+    /**
+     * @return any reprompts associated with this prompt.
+     */
+    public FinalizedPrompt[] getReprompts() {
+        return reprompts;
+    }
+
+    /**
+     * @return {@code true} if the conversation should end after the current
+     * prompt is delivered; {@code false} otherwise.
+     */
+    public boolean endsConversation() {
+        return endsConversation;
+    }
+
+    @Override
+    public String toString() {
+        return "Prompt{"
+              + "id='" + id + '\''
+              + ", text='" + text + '\''
+              + ", voice='" + voice + '\''
+              + ", proposal=" + proposal
+              + ", reprompts=" + Arrays.toString(reprompts)
+              + ", endsConversation=" + endsConversation
+              + '}';
+    }
+
+    /**
+     * Prompt builder API.
+     */
+    public static final class Builder {
+
+        private final String id;
+        private final String text;
+        private String voice;
+        private Proposal proposal;
+        private FinalizedPrompt[] reprompts;
+        private boolean endsConversation;
+
+        /**
+         * Create a new prompt builder with the minimal set of required data.
+         *
+         * @param promptId  The prompt's ID.
+         * @param textReply A reply template formatted for print.
+         */
+        public Builder(@NonNull String promptId, @NonNull String textReply) {
+            this.id = promptId;
+            this.text = textReply;
+            this.reprompts = new FinalizedPrompt[0];
+        }
+
+        /**
+         * Signals that the prompt to be built should end the conversation with
+         * the user.
+         *
+         * @return the updated builder
+         */
+        public Builder endsConversation() {
+            this.endsConversation = true;
+            return this;
+        }
+
+        /**
+         * Add a reply template formatted for TTS synthesis to the current
+         * prompt.
+         *
+         * @param voiceReply The voice prompt to be added.
+         * @return the updated builder
+         */
+        public Builder withVoice(@NonNull String voiceReply) {
+            this.voice = voiceReply;
+            return this;
+        }
+
+        /**
+         * Add a proposal to the current prompt.
+         *
+         * @param prop The proposal to be added.
+         * @return the updated builder
+         */
+        public Builder withProposal(@NonNull Proposal prop) {
+            this.proposal = prop;
+            return this;
+        }
+
+        /**
+         * Specify reprompts for the current prompt.
+         *
+         * @param prompts The reprompts to attach.
+         * @return the updated builder
+         */
+        public Builder withReprompts(@NonNull List<FinalizedPrompt> prompts) {
+            this.reprompts = prompts.toArray(new FinalizedPrompt[0]);
+            return this;
+        }
+
+        /**
+         * @return a complete prompt created from the current builder state.
+         */
+        public FinalizedPrompt build() {
+            return new FinalizedPrompt(this);
+        }
+    }
+}

--- a/src/main/java/io/spokestack/spokestack/dialogue/InMemoryConversationData.java
+++ b/src/main/java/io/spokestack/spokestack/dialogue/InMemoryConversationData.java
@@ -6,6 +6,11 @@ import java.util.Map;
 /**
  * A simple data store for conversation data that resides in memory and lasts
  * only as long as the dialogue manager holding it.
+ *
+ * <p>
+ * Formats values for both display and synthesis using {@link
+ * String#valueOf(Object)}.
+ * </p>
  */
 public class InMemoryConversationData implements ConversationData {
 

--- a/src/main/java/io/spokestack/spokestack/dialogue/Prompt.java
+++ b/src/main/java/io/spokestack/spokestack/dialogue/Prompt.java
@@ -2,6 +2,7 @@ package io.spokestack.spokestack.dialogue;
 
 import androidx.annotation.NonNull;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -125,6 +126,32 @@ public final class Prompt {
      */
     public boolean endsConversation() {
         return endsConversation;
+    }
+
+    /**
+     * Finalize this prompt, filling in all placeholders with data from the
+     * conversation's data store.
+     *
+     * @param dataStore The current state of the conversation data to use for
+     *                  filling placeholders in prompts.
+     * @return A finalized version of this prompt ready for display/synthesis.
+     */
+    public FinalizedPrompt finalizePrompt(ConversationData dataStore) {
+        List<FinalizedPrompt> finalReprompts = new ArrayList<>();
+        for (Prompt prompt : this.reprompts) {
+            finalReprompts.add(prompt.finalizePrompt(dataStore));
+        }
+
+        FinalizedPrompt.Builder builder = new FinalizedPrompt.Builder(
+              this.id, this.getText(dataStore))
+              .withVoice(this.getVoice(dataStore))
+              .withProposal(this.proposal)
+              .withReprompts(finalReprompts);
+
+        if (this.endsConversation) {
+            builder.endsConversation();
+        }
+        return builder.build();
     }
 
     @Override

--- a/src/main/java/io/spokestack/spokestack/dialogue/policy/RuleBasedDialoguePolicy.java
+++ b/src/main/java/io/spokestack/spokestack/dialogue/policy/RuleBasedDialoguePolicy.java
@@ -57,8 +57,8 @@ import static io.spokestack.spokestack.dialogue.policy.Model.*;
  * </p>
  * <ul>
  *   <li>
- *      <b>dialogue-policy-file</b> (string, required): file system path to the dialogue
- *      policy configuration.
+ *      <b>dialogue-policy-file</b> (string, required): file system path to the
+ *         dialogue policy configuration.
  *   </li>
  * </ul>
  */

--- a/src/main/java/io/spokestack/spokestack/rasa/RasaDialoguePolicy.java
+++ b/src/main/java/io/spokestack/spokestack/rasa/RasaDialoguePolicy.java
@@ -1,0 +1,152 @@
+package io.spokestack.spokestack.rasa;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.reflect.TypeToken;
+import io.spokestack.spokestack.SpeechConfig;
+import io.spokestack.spokestack.dialogue.ConversationData;
+import io.spokestack.spokestack.dialogue.ConversationState;
+import io.spokestack.spokestack.dialogue.DialogueDispatcher;
+import io.spokestack.spokestack.dialogue.DialogueEvent;
+import io.spokestack.spokestack.dialogue.DialoguePolicy;
+import io.spokestack.spokestack.dialogue.Prompt;
+import io.spokestack.spokestack.nlu.NLUResult;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * A dialogue policy that examines the response from a Rasa Open Source server
+ * retrieved by a {@link RasaOpenSourceNLU} component and dispatches events
+ * based on its contents.
+ *
+ * <p>
+ * A {@code text} response is dispatched as a {@code PROMPT} event, and an image
+ * is dispatched as an {@code ACTION} event with an {@code appAction} of {@code
+ * "displayImage"} and a {@code systemPrompt} containing the image URL.
+ * </p>
+ *
+ * <p>
+ * Intents that do not match the one produced by {@link RasaOpenSourceNLU} are
+ * not supported and will result in {@code ERROR} events.
+ * </p>
+ */
+public final class RasaDialoguePolicy implements DialoguePolicy {
+    private static final String IMAGE_ACTION = "displayImage";
+
+    private final Gson gson;
+
+    /**
+     * Create a new dialogue policy for handling responses from Rasa Open
+     * Source.
+     *
+     * @param speechConfig configuration properties for this policy.
+     */
+    public RasaDialoguePolicy(SpeechConfig speechConfig) {
+        this.gson = new Gson();
+    }
+
+    @Override
+    public String dump(ConversationData conversationData) {
+        // unnecessary - all state is managed on the Rasa server
+        return "";
+    }
+
+    @Override
+    public void load(String state, ConversationData conversationData) {
+        // unnecessary - all state is managed on the Rasa server
+    }
+
+    @Override
+    public void handleTurn(
+          NLUResult userTurn,
+          ConversationData conversationData,
+          DialogueDispatcher eventDispatcher) {
+        String intent = userTurn.getIntent();
+        if (!intent.equals(RasaOpenSourceNLU.RASA_INTENT)) {
+            // we can't handle non-Rasa intents
+            dispatchError(eventDispatcher, "non-Rasa intent: " + intent);
+        }
+
+        List<RasaResponse> responses = getResponses(userTurn, eventDispatcher);
+        for (RasaResponse response : responses) {
+            // guard against trailing commas in the json
+            if (response != null) {
+                dispatchResponse(eventDispatcher, response);
+            }
+        }
+    }
+
+    private void dispatchError(DialogueDispatcher dispatcher, String msg) {
+        ConversationState state = new ConversationState.Builder()
+              .withError(msg)
+              .build();
+        DialogueEvent event =
+              new DialogueEvent(DialogueEvent.Type.ERROR, state);
+        dispatcher.dispatch(event);
+    }
+
+    private List<RasaResponse> getResponses(NLUResult userTurn,
+                                            DialogueDispatcher dispatcher) {
+        Object response = userTurn.getContext()
+              .get(RasaOpenSourceNLU.RESPONSE_KEY);
+        String json = String.valueOf(response);
+        List<RasaResponse> responses = null;
+        try {
+            responses = this.gson.fromJson(json, RasaResponse.TYPE);
+        } catch (JsonSyntaxException e) {
+            // let the null check below handle the error
+        }
+
+        if (responses == null) {
+           dispatchError(dispatcher, "invalid server response: " + json);
+           return new ArrayList<>();
+        }
+        return responses;
+    }
+
+    private void dispatchResponse(DialogueDispatcher dispatcher,
+                                  RasaResponse response) {
+        DialogueEvent.Type eventType = null;
+        ConversationState.Builder state = new ConversationState.Builder();
+
+        if (response.text != null) {
+            String id = String.valueOf(response.text.hashCode());
+            Prompt prompt = new Prompt.Builder(id, response.text).build();
+            state.withPrompt(prompt);
+            eventType = DialogueEvent.Type.PROMPT;
+        } else if (response.image != null) {
+            String id = String.valueOf(response.image.hashCode());
+            Prompt prompt = new Prompt.Builder(id, response.image).build();
+            state
+                  .withPrompt(prompt)
+                  .withAction(IMAGE_ACTION, new HashMap<>());
+            eventType = DialogueEvent.Type.ACTION;
+        }
+
+        if (eventType != null) {
+            DialogueEvent event = new DialogueEvent(eventType, state.build());
+            dispatcher.dispatch(event);
+        }
+    }
+
+    @Override
+    public void completeTurn(
+          boolean success,
+          ConversationData conversationData,
+          DialogueDispatcher eventDispatcher) {
+
+    }
+
+    /**
+     * Wrapper class used to deserialize JSON responses from Rasa Open Source.
+     */
+    private static class RasaResponse {
+        private static final Type TYPE =
+              new TypeToken<ArrayList<RasaResponse>>() {}.getType();
+        private String text;
+        private String image;
+    }
+}

--- a/src/main/java/io/spokestack/spokestack/rasa/RasaOpenSourceNLU.java
+++ b/src/main/java/io/spokestack/spokestack/rasa/RasaOpenSourceNLU.java
@@ -1,0 +1,196 @@
+package io.spokestack.spokestack.rasa;
+
+import com.google.gson.Gson;
+import io.spokestack.spokestack.SpeechConfig;
+import io.spokestack.spokestack.nlu.NLUContext;
+import io.spokestack.spokestack.nlu.NLUResult;
+import io.spokestack.spokestack.nlu.NLUService;
+import io.spokestack.spokestack.util.AsyncResult;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An NLU component that submits utterances to a Rasa Open Source server to
+ * retrieve responses.
+ *
+ * <p>
+ * Since the input for a Rasa Open Source request is a user utterance, this
+ * component occupies the position in Spokestack of an NLU, but a Rasa webhook
+ * response includes results from the dialogue model, leaving out NLU results.
+ * Therefore, this component returns a constant value as the intent and
+ * includes the webhook response as a list inside the result context under a
+ * {@code "responses"} key.
+ * </p>
+ *
+ * <p>
+ * This component is designed to be used with a {@link io.spokestack.spokestack.dialogue.DialogueManager}
+ * built with a {@link RasaDialoguePolicy} policy, which expects results in
+ * the format just described and converts the Rasa responses into TTS
+ * prompts or app events as appropriate.
+ * </p>
+ *
+ * <p>
+ * This component supports the following configuration properties:
+ * </p>
+ * <ul>
+ *   <li>
+ *      <b>rasa-oss-url</b> (string, required): URL to the Rasa Open Source
+ *      server. This component is designed to use Rasa's REST channel.
+ *   </li>
+ *   <li>
+ *      <b>rasa-sender-id</b> (string, optional): Sender ID for Rasa requests.
+ *      Defaults to "spokestack-android".
+ *   </li>
+ *   <li>
+ *      <b>rasa-oss-token</b> (string, optional): Token to use in requests to
+ *      the Rasa Open Source server. See
+ *      <a href="https://rasa.com/docs/rasa/http-api#token-based-auth">Rasa's
+ *      documentation</a> for more details.
+ *   </li>
+ *   <li>
+ *      <b>rasa-oss-jwt</b> (string, optional): A full JWT header (including
+ *      the "Bearer " prefix) to use in requests to the Rasa Open Source server.
+ *      See <a href="https://rasa.com/docs/rasa/http-api#jwt-based-auth">Rasa's
+ *      documentation</a> for more details.
+ *   </li>
+ * </ul>
+ */
+public final class RasaOpenSourceNLU implements NLUService {
+
+    /**
+     * The designated intent produced by this component since Rasa Open Source
+     * responses do not include classification results.
+     */
+    public static final String RASA_INTENT = "rasa.core";
+
+    /**
+     * The designated key for response messages from Rasa Open Source in an
+     * {@link NLUResult} produced by this component.
+     */
+    public static final String RESPONSE_KEY = "responses";
+
+    private static final String DEFAULT_SENDER = "spokestack-android";
+    private static final MediaType APPLICATION_JSON =
+          MediaType.parse("application/json");
+
+    private final ExecutorService executor =
+          Executors.newSingleThreadExecutor();
+
+    private final String coreUrl;
+    private final String token;
+    private final String jwt;
+    private final String senderId;
+    private final NLUContext context;
+    private final OkHttpClient httpClient;
+    private final Gson gson;
+
+    /**
+     * Create a new Rasa Open Source NLU component.
+     *
+     * @param config     configuration properties
+     * @param nluContext The NLU context used to dispatch trace events and
+     *                   errors.
+     */
+    public RasaOpenSourceNLU(SpeechConfig config, NLUContext nluContext) {
+        this(config,
+              nluContext,
+              new OkHttpClient.Builder()
+                    .connectTimeout(5, TimeUnit.SECONDS)
+                    .readTimeout(5, TimeUnit.SECONDS)
+                    .build()
+        );
+    }
+
+    RasaOpenSourceNLU(SpeechConfig config,
+                      NLUContext nluContext,
+                      OkHttpClient client) {
+        this.coreUrl = config.getString("rasa-oss-url");
+        this.token = config.getString("rasa-oss-token", null);
+        this.jwt = config.getString("rasa-oss-jwt", null);
+        this.senderId = config.getString("rasa-sender-id", DEFAULT_SENDER);
+        this.context = nluContext;
+        this.gson = new Gson();
+        this.httpClient = client;
+    }
+
+    @Override
+    public AsyncResult<NLUResult> classify(String utterance,
+                                           NLUContext nluContext) {
+
+        AsyncResult<NLUResult> asyncResult = new AsyncResult<>(
+              () -> requestClassification(utterance)
+        );
+        this.executor.submit(asyncResult);
+        return asyncResult;
+    }
+
+    private NLUResult requestClassification(String utterance) {
+        NLUResult.Builder resultBuilder = new NLUResult.Builder(utterance);
+        try {
+            Request request = buildRequest(utterance);
+            Response response = httpClient.newCall(request).execute();
+            String body = "<no body>";
+            ResponseBody responseBody = response.body();
+
+            if (responseBody != null) {
+                body = responseBody.string();
+            }
+
+            if (response.isSuccessful()) {
+                Map<String, Object> rasaMeta = new HashMap<>();
+                rasaMeta.put(RESPONSE_KEY, body);
+                resultBuilder
+                      .withContext(rasaMeta)
+                      .withIntent(RASA_INTENT)
+                      .withConfidence(1.0f);
+            } else {
+                this.context.traceError("Rasa HTTP error (%d): %s",
+                      response.code(), body);
+            }
+        } catch (IOException e) {
+            resultBuilder.withError(e);
+        }
+        return resultBuilder.build();
+    }
+
+    private Request buildRequest(String utterance) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("sender", this.senderId);
+        body.put("message", utterance);
+
+        if (this.token != null) {
+            body.put("token", this.token);
+        }
+
+        String fullBodyJson = gson.toJson(body);
+        RequestBody postBody =
+              RequestBody.create(fullBodyJson, APPLICATION_JSON);
+
+        Request.Builder builder = new Request.Builder();
+
+        if (this.jwt != null) {
+            builder = builder.addHeader("Authorization", this.jwt);
+        }
+
+        return builder
+              .url(this.coreUrl)
+              .post(postBody)
+              .build();
+    }
+
+    @Override
+    public void close() throws Exception {
+        this.executor.shutdownNow();
+    }
+}

--- a/src/main/java/io/spokestack/spokestack/rasa/package-info.java
+++ b/src/main/java/io/spokestack/spokestack/rasa/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * This package contains components used to perform NLU with Rasa NLU.
+ */
+package io.spokestack.spokestack.rasa;

--- a/src/main/resources/checkstyle.xml
+++ b/src/main/resources/checkstyle.xml
@@ -140,7 +140,9 @@ io.spokestack.spokestack.dialogue.policy.DialogueAct"/>
         <module name="ParenPad"/>
         <module name="TypecastParenPad"/>
         <module name="WhitespaceAfter"/>
-        <module name="WhitespaceAround"/>
+        <module name="WhitespaceAround">
+            <property name="allowEmptyTypes" value="true"/>
+        </module>
 
         <!-- Modifier Checks                                    -->
         <!-- See http://checkstyle.sf.net/config_modifiers.html -->

--- a/src/test/java/io/spokestack/spokestack/SpokestackTest.java
+++ b/src/test/java/io/spokestack/spokestack/SpokestackTest.java
@@ -56,6 +56,7 @@ public class SpokestackTest {
         Spokestack.Builder noOutputBuilder = new Spokestack.Builder()
               .withoutSpeechPipeline()
               .withoutNlu()
+              .withoutDialogueManagement()
               .withoutAutoPlayback();
         noOutputBuilder.getTtsBuilder().setTTSServiceClass(
               "io.spokestack.spokestack.tts.TTSTestUtils$Service");
@@ -71,6 +72,7 @@ public class SpokestackTest {
               .withoutWakeword()
               .withoutSpeechPipeline()
               .withoutNlu()
+              .withoutDialogueManagement()
               .withoutTts()
               .withoutAutoPlayback()
               .setProperty("test", "test")
@@ -90,6 +92,7 @@ public class SpokestackTest {
               .withoutWakeword()
               .withoutNlu()
               .withoutTts()
+              .withoutDialogueManagement()
               .addListener(listener);
 
         builder.getPipelineBuilder().setStageClasses(new ArrayList<>());
@@ -225,13 +228,8 @@ public class SpokestackTest {
               .withoutWakeword()
               .addListener(listener);
 
+        builder = mockAndroidComponents(builder);
         Spokestack spokestack = new Spokestack(builder, mockNlu());
-
-        // handle context separately to make sure the convenience
-        // methods work
-        Context androidContext = mock(Context.class);
-
-        spokestack.setAndroidContext(androidContext);
 
         listener.setSpokestack(spokestack);
         TTSManager tts = spokestack.getTts();

--- a/src/test/java/io/spokestack/spokestack/dialogue/DialogueManagerTest.java
+++ b/src/test/java/io/spokestack/spokestack/dialogue/DialogueManagerTest.java
@@ -90,6 +90,22 @@ public class DialogueManagerTest {
 
         manager.load("newState");
         assertEquals("newState", manager.dump());
+
+        // finalize a prompt
+        Prompt prompt = new Prompt.Builder("id", "{{text}}")
+              .withVoice("{{voice}}")
+              .withProposal(new Proposal())
+              .endsConversation()
+              .build();
+
+        conversationData.set("text", "123");
+        conversationData.set("voice", "one two three");
+
+        FinalizedPrompt finalized = prompt.finalizePrompt(conversationData);
+
+        assertEquals("123", finalized.getText());
+        assertEquals("one two three", finalized.getVoice());
+        assertTrue(finalized.endsConversation());
     }
 
     @Test

--- a/src/test/java/io/spokestack/spokestack/dialogue/PromptTest.java
+++ b/src/test/java/io/spokestack/spokestack/dialogue/PromptTest.java
@@ -53,4 +53,23 @@ public class PromptTest {
         assertEquals("one two three", reprompt.getVoice(data));
         assertTrue(reprompt.endsConversation());
     }
+
+    @Test
+    public void testFinalization() {
+        ConversationData data = new InMemoryConversationData();
+        Prompt prompt = new Prompt.Builder("id", "{{text}}")
+              .withVoice("{{voice}}")
+              .withProposal(new Proposal())
+              .endsConversation()
+              .build();
+
+        data.set("text", "123");
+        data.set("voice", "one two three");
+
+        FinalizedPrompt finalized = prompt.finalizePrompt(data);
+
+        assertEquals("123", finalized.getText());
+        assertEquals("one two three", finalized.getVoice());
+        assertTrue(finalized.endsConversation());
+    }
 }

--- a/src/test/java/io/spokestack/spokestack/rasa/RasaDialoguePolicyTest.java
+++ b/src/test/java/io/spokestack/spokestack/rasa/RasaDialoguePolicyTest.java
@@ -1,0 +1,115 @@
+package io.spokestack.spokestack.rasa;
+
+import io.spokestack.spokestack.SpeechConfig;
+import io.spokestack.spokestack.dialogue.ConversationData;
+import io.spokestack.spokestack.dialogue.DialogueDispatcher;
+import io.spokestack.spokestack.dialogue.DialogueEvent;
+import io.spokestack.spokestack.dialogue.DialogueListener;
+import io.spokestack.spokestack.dialogue.InMemoryConversationData;
+import io.spokestack.spokestack.dialogue.Prompt;
+import io.spokestack.spokestack.nlu.NLUResult;
+import io.spokestack.spokestack.util.EventTracer;
+import junit.framework.TestListener;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+
+public class RasaDialoguePolicyTest {
+
+    @Test
+    public void unusedMethods() {
+        RasaDialoguePolicy policy = new RasaDialoguePolicy(testConfig());
+        ConversationData dataStore = new InMemoryConversationData();
+        dataStore.set("key", "val");
+        assertEquals("", policy.dump(dataStore));
+        policy.load("state", dataStore);
+    }
+
+    @Test
+    public void testEvents() throws InterruptedException {
+        RasaDialoguePolicy policy = new RasaDialoguePolicy(testConfig());
+        ConversationData dataStore = new InMemoryConversationData();
+        TestListener listener = new TestListener();
+        DialogueDispatcher dispatcher = testDispatcher(listener);
+        // null response throws an error
+        String response = null;
+        NLUResult result = rasaResult(response);
+        policy.handleTurn(result, dataStore, dispatcher);
+        DialogueEvent event = listener.events.poll(500, TimeUnit.MILLISECONDS);
+        assertNotNull(event);
+        assertEquals(DialogueEvent.Type.ERROR, event.type);
+
+        // empty response throws an error
+        response = "{}";
+        result = rasaResult(response);
+        policy.handleTurn(result, dataStore, dispatcher);
+        event = listener.events.poll(500, TimeUnit.MILLISECONDS);
+        assertNotNull(event);
+        assertEquals(DialogueEvent.Type.ERROR, event.type);
+
+        String prompt = "hi";
+        String imageURL = "https://example.com";
+        response = "[" +
+              "{\"recipient_id\": \"id\", \"text\": \"" + prompt + "\"}," +
+              "{\"recipient_id\": \"id\", \"image\": \"" + imageURL + "\"}," +
+              "]";
+        result = rasaResult(response);
+        policy.handleTurn(result, dataStore, dispatcher);
+        List<DialogueEvent> events = new ArrayList<>();
+        listener.events.drainTo(events);
+        event = events.get(0);
+        assertEquals(DialogueEvent.Type.PROMPT, event.type);
+        String receivedPrompt = event.state.getPrompt().getText(dataStore);
+        assertEquals(prompt, receivedPrompt);
+        event = events.get(1);
+        assertEquals(DialogueEvent.Type.ACTION, event.type);
+        String receivedURL = event.state.getPrompt().getText(dataStore);
+        assertEquals(imageURL, receivedURL);
+    }
+
+    private SpeechConfig testConfig() {
+        SpeechConfig config = new SpeechConfig();
+        config.put("sample-rate", 16000);
+        config.put("frame-width", 20);
+        config.put("buffer-width", 300);
+        return config;
+    }
+
+    private DialogueDispatcher testDispatcher(DialogueListener listener) {
+        int level = EventTracer.Level.INFO.value();
+        List<DialogueListener> listeners = new ArrayList<>();
+        listeners.add(listener);
+        return new DialogueDispatcher(level, listeners);
+    }
+
+    private NLUResult rasaResult(String response) {
+        HashMap<String, Object> rasaContext = new HashMap<>();
+        rasaContext.put(RasaOpenSourceNLU.RESPONSE_KEY, response);
+        return new NLUResult.Builder("test utterance")
+              .withIntent(RasaOpenSourceNLU.RASA_INTENT)
+              .withContext(rasaContext)
+              .build();
+    }
+
+    static class TestListener implements DialogueListener {
+        LinkedBlockingQueue<DialogueEvent> events = new LinkedBlockingQueue<>();
+
+        @Override
+        public void onDialogueEvent(@NotNull DialogueEvent event) {
+            events.add(event);
+        }
+
+        @Override
+        public void onTrace(@NotNull EventTracer.Level level,
+                            @NotNull String message) {
+            // no-op
+        }
+    }
+}


### PR DESCRIPTION
This introduces a basic integration with Rasa's Open Source server via its [webhook API](https://rasa.com/docs/rasa/http-api). Because NLU and dialogue management are both handled by a single request to the server, this includes both an NLU component and a dialogue policy. The Rasa server returns final responses instead of NLU results, so the NLU component here uses a hardcoded intent and metadata in the result that's designed to be interpreted by the dialogue policy.

In the future, we could add a separate Rasa NLU component that uses the `parse` endpoint to get raw NLU results, thus separating NLU from dialogue management, but this version minimizes the effort involved in migrating an existing Rasa chatbot to mobile.
