### PR TITLE
update OKHttp dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
       <dependency>
          <groupId>com.squareup.okhttp3</groupId>
          <artifactId>okhttp</artifactId>
-         <version>4.2.2</version>
+         <version>4.9.1</version>
       </dependency>
       <dependency>
          <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
This addresses an error in the logs on startup when running on Android API 30. The error doesn't appear to affect program functionality, but it can make it look like there are SSL problems. Running with the latest OKHttp eliminates the log.