### PR TITLE
fix: enforce ordering of TTS responses

### DIFF
--- a/src/main/java/io/spokestack/spokestack/tts/SpokestackTTSClient.java
+++ b/src/main/java/io/spokestack/spokestack/tts/SpokestackTTSClient.java
@@ -107,11 +107,7 @@ public final class SpokestackTTSClient {
      *                and any additional metadata.
      */
     public void synthesize(SynthesisRequest request) {
-        HashMap<String, String> headers = new HashMap<>();
         String requestId = request.metadata.get("id");
-        if (requestId != null) {
-            headers.put("x-request-id", requestId);
-        }
 
         HashMap<String, String> variables = new HashMap<>();
         String param = "text";
@@ -135,12 +131,16 @@ public final class SpokestackTTSClient {
         }
         variables.put("voice", request.voice);
         String queryString = String.format(GRAPHQL_QUERY, param, method);
-        postSpeech(headers, queryString, variables);
+        postSpeech(requestId, queryString, variables);
     }
 
-    private void postSpeech(Map<String, String> headers,
+    private void postSpeech(String requestId,
                             String queryString,
                             Map<String, String> variables) {
+        HashMap<String, String> headers = new HashMap<>();
+        if (requestId != null) {
+            headers.put("x-request-id", requestId);
+        }
         if (this.ttsApiId == null) {
             ttsCallback.onError("API ID not provided");
             return;

--- a/src/main/java/io/spokestack/spokestack/tts/SynthesisRequest.java
+++ b/src/main/java/io/spokestack/spokestack/tts/SynthesisRequest.java
@@ -2,6 +2,7 @@ package io.spokestack.spokestack.tts;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * <p>
@@ -164,7 +165,7 @@ public class SynthesisRequest {
         private CharSequence textToSynthesize;
         private Mode synthesisMode = Mode.TEXT;
         private String ttsVoice = "demo-male";
-        private Map<String, String> metadata = new HashMap<>();
+        private HashMap<String, String> metadata = new HashMap<>();
 
         /**
          * Create a new {@code TTSInput} builder with the only required data,
@@ -208,7 +209,7 @@ public class SynthesisRequest {
          * @return The current builder.
          */
         public Builder withData(Map<String, String> requestData) {
-            this.metadata = requestData;
+            this.metadata.putAll(requestData);
             return this;
         }
 
@@ -220,6 +221,11 @@ public class SynthesisRequest {
          * builder.
          */
         public SynthesisRequest build() {
+            // add a random request ID if one doesn't exist
+            if (!metadata.containsKey("id")) {
+                UUID id = UUID.randomUUID();
+                metadata.put("id", id.toString());
+            }
             return new SynthesisRequest(textToSynthesize, synthesisMode,
                   ttsVoice, metadata);
         }

--- a/src/test/java/io/spokestack/spokestack/tts/SpokestackTTSServiceTest.java
+++ b/src/test/java/io/spokestack/spokestack/tts/SpokestackTTSServiceTest.java
@@ -160,6 +160,7 @@ public class SpokestackTTSServiceTest {
         public Response intercept(@NotNull Chain chain) throws IOException {
             Request request = chain.request();
             RequestBody body = request.body();
+            String requestId = request.header("x-request-id");
             Buffer buffer = new Buffer();
             body.writeTo(buffer);
             Map json = gson.fromJson(buffer.readUtf8(), Map.class);
@@ -169,10 +170,11 @@ public class SpokestackTTSServiceTest {
                 throw new IOException("test exc");
             }
 
-            return createResponse(text == null);
+            return createResponse(requestId, text == null);
         }
 
-        private Response createResponse(boolean isSsml) throws IOException {
+        private Response createResponse(String requestId,
+                                        boolean isSsml) throws IOException {
             Request request = new okhttp3.Request.Builder()
                   .url("http://example.com/")
                   .build();
@@ -185,6 +187,7 @@ public class SpokestackTTSServiceTest {
             when(body.source()).thenReturn(responseSource);
             return new Response.Builder()
                   .request(request)
+                  .header("x-request-id", requestId)
                   .protocol(okhttp3.Protocol.HTTP_1_1)
                   .code(200)
                   .message("OK")

--- a/src/test/java/io/spokestack/spokestack/tts/TTSManagerTest.java
+++ b/src/test/java/io/spokestack/spokestack/tts/TTSManagerTest.java
@@ -11,7 +11,10 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
@@ -24,11 +27,11 @@ public class TTSManagerTest implements TTSListener {
     @Mock
     private final Context context = mock(Context.class);
 
-    private TTSEvent lastEvent;
+    private List<TTSEvent> events = new ArrayList<>();
 
     @Before
     public void before() {
-        lastEvent = null;
+        events.clear();
     }
 
     @Test
@@ -51,13 +54,12 @@ public class TTSManagerTest implements TTSListener {
         TTSManager manager = new TTSManager.Builder()
               .setTTSServiceClass("io.spokestack.spokestack.tts.TTSTestUtils$Service")
               .setOutputClass("io.spokestack.spokestack.tts.TTSTestUtils$Output")
-              .setProperty("spokestack-id", "test")
               .setConfig(new SpeechConfig())
               .setAndroidContext(context)
               .addTTSListener(this)
               .build();
 
-        LinkedBlockingQueue<String> events =
+        LinkedBlockingQueue<String> outputEvents =
               ((TTSTestUtils.Output) manager.getOutput()).getEvents();
 
         manager.prepare();
@@ -70,14 +72,17 @@ public class TTSManagerTest implements TTSListener {
               .withData(Collections.singletonMap("key", "value"))
               .build();
         manager.synthesize(request);
-        String event = events.poll(1, TimeUnit.SECONDS);
+        String event = outputEvents.poll(1, TimeUnit.SECONDS);
         assertEquals("audioReceived", event, "audioReceived not called");
+        TTSEvent lastEvent = this.events.get(0);
         assertEquals(TTSEvent.Type.AUDIO_AVAILABLE, lastEvent.type);
         assertEquals(Uri.EMPTY, lastEvent.getTtsResponse().getAudioUri());
 
         manager.close();
         assertNull(manager.getTtsService());
         assertNull(manager.getOutput());
+
+        this.events.clear();
 
         // re-preparation is allowed
         manager.prepare();
@@ -86,6 +91,7 @@ public class TTSManagerTest implements TTSListener {
 
         String errorMsg = "can't close won't close";
         manager.close();
+        lastEvent = this.events.get(0);
         assertEquals(TTSEvent.Type.ERROR, lastEvent.type);
         assertEquals(errorMsg, lastEvent.getError().getMessage());
     }
@@ -94,7 +100,6 @@ public class TTSManagerTest implements TTSListener {
     public void testStop() throws Exception {
         TTSManager manager = new TTSManager.Builder()
               .setTTSServiceClass("io.spokestack.spokestack.tts.TTSTestUtils$Service")
-              .setProperty("spokestack-id", "test")
               .setConfig(new SpeechConfig())
               .setAndroidContext(context)
               .addTTSListener(this)
@@ -106,7 +111,6 @@ public class TTSManagerTest implements TTSListener {
         manager = new TTSManager.Builder()
               .setTTSServiceClass("io.spokestack.spokestack.tts.TTSTestUtils$Service")
               .setOutputClass("io.spokestack.spokestack.tts.TTSTestUtils$Output")
-              .setProperty("spokestack-id", "test")
               .setConfig(new SpeechConfig())
               .setAndroidContext(context)
               .addTTSListener(this)
@@ -119,8 +123,38 @@ public class TTSManagerTest implements TTSListener {
         assertEquals("stop", events.remove(), "stop not called on output");
     }
 
+    @Test
+    public void testQueue() throws Exception {
+        CountDownLatch latch = new CountDownLatch(2);
+        TTSManager manager = new TTSManager.Builder()
+              .setTTSServiceClass("io.spokestack.spokestack.tts.TTSTestUtils$Service")
+              .setConfig(new SpeechConfig())
+              .setProperty("service-latch", latch)
+              .setAndroidContext(context)
+              .addTTSListener(this)
+              .build();
+
+        SynthesisRequest request = new SynthesisRequest.Builder("test")
+              .build();
+
+        TTSTestUtils.Service ttsService =
+              (TTSTestUtils.Service) manager.getTtsService();
+
+        new Thread(() -> manager.synthesize(request)).start();
+        new Thread(() -> manager.synthesize(request)).start();
+        latch.await(1, TimeUnit.SECONDS);
+
+        String[] expected =
+              new String[] {"synthesize", "deliver", "synthesize", "deliver"};
+        assertEquals(4, ttsService.calls.size());
+        for (int i = 0; i < ttsService.calls.size(); i++) {
+            assertEquals(expected[i], ttsService.calls.get(i),
+                  "failed at item " + i);
+        }
+    }
+
     @Override
     public void eventReceived(@NonNull TTSEvent event) {
-        lastEvent = event;
+        this.events.add(event);
     }
 }

--- a/src/test/java/io/spokestack/spokestack/tts/TTSTestUtils.java
+++ b/src/test/java/io/spokestack/spokestack/tts/TTSTestUtils.java
@@ -4,30 +4,106 @@ import android.content.Context;
 import android.net.Uri;
 import io.spokestack.spokestack.SpeechConfig;
 import io.spokestack.spokestack.SpeechOutput;
-import org.jetbrains.annotations.NotNull;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import okio.BufferedSource;
 
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TTSTestUtils {
+    public static final String AUDIO_URL = "https://spokestack.io/tts/test.mp3";
+
+    /**
+     * JSON for a GraphQL response to {@code synthesizeText}.
+     */
+    public static final String TEXT_JSON =
+          "{\"data\": {\"synthesizeText\": {\"url\": \""
+                + AUDIO_URL + "\"}}}";
+
+    /**
+     * JSON for a GraphQL SSML error.
+     */
+    public static final String ERROR_JSON =
+          "{\"data\": null, "
+                + "\"errors\": [{\"message\": \"invalid_ssml\" }]}";
+
+    /**
+     * Creates an OKHttp {@code Response} with the specified body.
+     */
+    public static Response createHttpResponse(Request request, String body)
+          throws IOException {
+        ResponseBody responseBody = mock(ResponseBody.class);
+        BufferedSource source = mock(BufferedSource.class);
+        when(source.readString(any(Charset.class))).thenReturn(body);
+        when(responseBody.source()).thenReturn(source);
+        Response.Builder builder = new Response.Builder()
+              .request(request)
+              .protocol(okhttp3.Protocol.HTTP_1_1)
+              .code(200)
+              .message("OK")
+              .body(responseBody);
+
+        String requestId = request.header("x-request-id");
+        if (requestId != null) {
+            builder.header("x-request-id", requestId);
+        }
+
+        return builder.build();
+    }
 
     public static class Service extends TTSService {
+
+        List<String> calls = new ArrayList<>();
+        CountDownLatch latch;
 
         public Service(SpeechConfig config) {
             String key = config.getString("spokestack-id", "default");
             if (!key.equals("default")) {
                 fail("custom client ID should not be set by tests");
             }
+            Object latch = config.getParams().get("service-latch");
+            this.latch = (CountDownLatch) latch;
         }
 
         @Override
         public void synthesize(SynthesisRequest request) {
+            this.calls.add("synthesize");
+            try {
+                deliverResponse(request);
+            } catch (InterruptedException e) {
+                fail();
+            }
+        }
+
+        public void deliverResponse(SynthesisRequest request)
+              throws InterruptedException {
+            Thread.sleep(10);
             TTSEvent synthesisComplete =
                   new TTSEvent(TTSEvent.Type.AUDIO_AVAILABLE);
-            AudioResponse response = new AudioResponse(Uri.EMPTY);
+            Map<String, Object> responseMeta = new HashMap<>();
+            for (Map.Entry<String, String> entry : request.metadata.entrySet()) {
+                responseMeta.put(entry.getKey(), entry.getValue());
+            }
+            AudioResponse response = new AudioResponse(responseMeta, Uri.EMPTY);
             synthesisComplete.setTtsResponse(response);
+            this.calls.add("deliver");
             dispatch(synthesisComplete);
+            if (this.latch != null) {
+                this.latch.countDown();
+            }
         }
 
         @Override


### PR DESCRIPTION
I'd like a sanity check on the implementation here to make sure I'm not overcomplicating things. Requests have to be async, so I need to impose some external ordering on the responses.

---

Currently, TTS requests submitted in close proximity
can result in audio being delivered to the client in a
different order than the requests were submitted.

This change keeps the requests asynchronous (as they must
be for Android networking) while enforcing ordering for the
results by introducing a request queue in the TTS manager.