### PR TITLE
fix: ensure pipeline is resumed when tts stops

### DIFF
--- a/src/main/java/io/spokestack/spokestack/tts/SpokestackTTSOutput.java
+++ b/src/main/java/io/spokestack/spokestack/tts/SpokestackTTSOutput.java
@@ -184,8 +184,8 @@ public class SpokestackTTSOutput extends SpeechOutput
             if (this.mediaPlayer != null) {
                 mediaPlayer.stop(true);
             }
+            resetPlayerState();
         });
-        resetPlayerState();
     }
 
     @NotNull


### PR DESCRIPTION
Dumb fix here...the `Spokestack` wrapper resumes the pipeline when it receives an event signaling that playback has stopped, but we only send that event when we know we were playing content, in order to avoid spurious events caused by system sounds, etc.  `resetPlayerState` clears out that knowledge, and it's currently being run in a different thread than (and thus usually/always being executed before) the code that stops the media player.