### PR TITLE
feat: profile for wakeword + keyword ASR

### DIFF
--- a/src/main/java/io/spokestack/spokestack/profile/TFWakewordKeywordASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/TFWakewordKeywordASR.java
@@ -7,10 +7,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * A speech pipeline profile that uses voice activity detection to activate
- * ASR based on keyword detection. In other words, any speech will cause the
- * pipeline to activate, and {@code KeywordRecognizer} acts as the ASR
- * component, only transcribing utterances contained in its vocabulary.
+ * A speech pipeline profile that uses TensorFlow Lite for wakeword detection
+ * and keyword detection-based ASR. The pipeline will be activated by
+ * successful detection of the wakeword, and {@code KeywordRecognizer} will act
+ * as the ASR component, only transcribing utterances contained in its
+ * vocabulary. Properties related to signal processing are
+ * tuned for the "Spokestack" wakeword.
  *
  * <p>
  * The activation period ends either:
@@ -37,8 +39,33 @@ import java.util.List;
  * </p>
  *
  * <p>
- * The keyword detector requires extra configuration, which must be
- * added to the pipeline build process separately from this profile:
+ * Wakeword detection requires configuration to locate the models used for
+ * classification; these properties must be set separately from this profile:
+ * </p>
+ *
+ * <ul>
+ *   <li>
+ *      <b>wake-filter-path</b> (string, required): file system path to the
+ *      "filter" Tensorflow-Lite model, which is used to calculate a mel
+ *      spectrogram frame from the linear STFT; its inputs should be shaped
+ *      [fft-width], and its outputs [mel-width]
+ *   </li>
+ *   <li>
+ *      <b>wake-encode-path</b> (string, required): file system path to the
+ *      "encode" Tensorflow-Lite model, which is used to perform each
+ *      autoregressive step over the mel frames; its inputs should be shaped
+ *      [mel-length, mel-width], and its outputs [encode-width], with an
+ *      additional state input/output shaped [state-width]
+ *   </li>
+ *   <li>
+ *      <b>wake-detect-path</b> (string, required): file system path to the
+ *      "detect" Tensorflow-Lite model; its inputs shoudld be shaped
+ *      [encode-length, encode-width], and its outputs [1]
+ *   </li>
+ * </ul>
+ *
+ * <p>
+ * The keyword detector also requires configuration:
  * </p>
  *
  * <ul>
@@ -68,21 +95,29 @@ import java.util.List;
  *   </li>
  * </ul>
  *
+ * @see io.spokestack.spokestack.wakeword.WakewordTrigger
  * @see io.spokestack.spokestack.asr.KeywordRecognizer
  */
-public class VADTriggerKeywordASR implements PipelineProfile {
+public class TFWakewordKeywordASR implements PipelineProfile {
     @Override
     public SpeechPipeline.Builder apply(SpeechPipeline.Builder builder) {
         List<String> stages = new ArrayList<>();
         stages.add("io.spokestack.spokestack.webrtc.AutomaticGainControl");
         stages.add("io.spokestack.spokestack.webrtc.AcousticNoiseSuppressor");
         stages.add("io.spokestack.spokestack.webrtc.VoiceActivityDetector");
-        stages.add("io.spokestack.spokestack.webrtc.VoiceActivityTrigger");
+        stages.add("io.spokestack.spokestack.wakeword.WakewordTrigger");
         stages.add("io.spokestack.spokestack.ActivationTimeout");
         stages.add("io.spokestack.spokestack.asr.KeywordRecognizer");
 
         return builder
-              .setInputClass("io.spokestack.spokestack.android.MicrophoneInput")
+              .setInputClass(
+                    "io.spokestack.spokestack.android.MicrophoneInput")
+              .setProperty("ans-policy", "aggressive")
+              .setProperty("vad-mode", "very-aggressive")
+              .setProperty("vad-fall-delay", 800)
+              .setProperty("wake-threshold", 0.9)
+              .setProperty("pre-emphasis", 0.97)
+              .setProperty("wake-active-min", 1000)
               .setStageClasses(stages);
     }
 }

--- a/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
+++ b/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
@@ -25,6 +25,7 @@ public class SpeechPipelineTest implements OnSpeechEventListener {
           io.spokestack.spokestack.profile.TFWakewordAndroidASR.class,
           io.spokestack.spokestack.profile.TFWakewordAzureASR.class,
           io.spokestack.spokestack.profile.TFWakewordGoogleASR.class,
+          io.spokestack.spokestack.profile.TFWakewordKeywordASR.class,
           io.spokestack.spokestack.profile.TFWakewordSpokestackASR.class,
           io.spokestack.spokestack.profile.VADTriggerAndroidASR.class,
           io.spokestack.spokestack.profile.VADTriggerAzureASR.class,


### PR DESCRIPTION
This adds a pipeline profile to make it convenient to use a wake word detector combined with keyword ASR, providing TensorFlow-powered offline pipeline activation and limited-vocabulary ASR.