### PR TITLE
fix: refactor getOrDefault call for API < 24

### DIFF
--- a/src/main/java/io/spokestack/spokestack/nlu/tensorflow/WordpieceTextEncoder.java
+++ b/src/main/java/io/spokestack/spokestack/nlu/tensorflow/WordpieceTextEncoder.java
@@ -89,8 +89,11 @@ final class WordpieceTextEncoder implements TextEncoder {
     @Override
     public int encodeSingle(String token) {
         ensureReady();
-        return this.vocabulary.getOrDefault(token,
-              this.vocabulary.get(UNKNOWN));
+        Integer tokenId = this.vocabulary.get(token);
+        if (tokenId == null) {
+            tokenId = this.vocabulary.get(UNKNOWN);
+        }
+        return tokenId;
     }
 
     @Override


### PR DESCRIPTION
A call to a newer (by Android standards) Java method slipped in to the NLU module, making compatibility with Android API < 24 unnecessarily difficult. There's no reason the newer method is needed here, so I'm rolling it back to the old-school way of doing things.

Closes #157 .