### PR TITLE
various Azure fixes

### DIFF
--- a/src/main/java/io/spokestack/spokestack/microsoft/AzureSpeechRecognizer.java
+++ b/src/main/java/io/spokestack/spokestack/microsoft/AzureSpeechRecognizer.java
@@ -231,16 +231,13 @@ public class AzureSpeechRecognizer implements SpeechProcessor {
               SpeechRecognitionEventArgs recognitionArgs) {
             ResultReason reason = recognitionArgs.getResult().getReason();
             String transcript = recognitionArgs.getResult().getText();
-            boolean isFinal = (reason == ResultReason.RecognizedSpeech);
             if (!transcript.equals("")) {
-                if (isFinal) {
+                if (reason == ResultReason.RecognizedSpeech) {
                     dispatchResult(transcript, SpeechContext.Event.RECOGNIZE);
                 } else if (reason == ResultReason.RecognizingSpeech) {
                     dispatchResult(transcript,
                           SpeechContext.Event.PARTIAL_RECOGNIZE);
                 }
-            } else if (isFinal) {
-                this.speechContext.dispatch(SpeechContext.Event.TIMEOUT);
             }
         }
 

--- a/src/main/java/io/spokestack/spokestack/microsoft/AzureSpeechRecognizer.java
+++ b/src/main/java/io/spokestack/spokestack/microsoft/AzureSpeechRecognizer.java
@@ -52,7 +52,7 @@ import java.nio.ByteOrder;
  *      <b>frame-width</b> (integer): speech frame width, in ms
  *   </li>
  *   <li>
- *      <b>locale</b> (string): language code for speech recognition
+ *      <b>locale</b> (string): BCP-47 language code for speech recognition
  *   </li>
  *   <li>
  *      <b>azure-api-key</b> (string): API key for the Azure Speech
@@ -70,6 +70,7 @@ public class AzureSpeechRecognizer implements SpeechProcessor {
     private PushAudioInputStream audioStream;
     private AudioConfig audioConfig;
     private boolean active;
+    private String locale;
 
     // Azure speech requires little-endian (wav-format) data, so we buffer
     // audio frames internally to avoid mutating data coming from the speech
@@ -85,6 +86,10 @@ public class AzureSpeechRecognizer implements SpeechProcessor {
         String apiKey = speechConfig.getString("azure-api-key");
         String region = speechConfig.getString("azure-region");
         int sampleRate = speechConfig.getInteger("sample-rate");
+
+        if (speechConfig.containsKey("locale")) {
+            this.locale = speechConfig.getString("locale");
+        }
 
         if (sampleRate != 16000) {
             throw new IllegalArgumentException(
@@ -103,6 +108,11 @@ public class AzureSpeechRecognizer implements SpeechProcessor {
               com.microsoft.cognitiveservices.speech.SpeechConfig
                     .fromSubscription(apiKey, region);
         config.setProfanity(ProfanityOption.Raw);
+
+        if (this.locale != null) {
+            config.setSpeechRecognitionLanguage(this.locale);
+        }
+
         return config;
     }
 

--- a/src/main/java/io/spokestack/spokestack/microsoft/AzureSpeechRecognizer.java
+++ b/src/main/java/io/spokestack/spokestack/microsoft/AzureSpeechRecognizer.java
@@ -97,7 +97,7 @@ public class AzureSpeechRecognizer implements SpeechProcessor {
                         + sampleRate);
         }
 
-        this.buffer = ByteBuffer.allocateDirect(4096)
+        this.buffer = ByteBuffer.allocateDirect(1500)
               .order(ByteOrder.LITTLE_ENDIAN);
         this.msConfig = createMsConfig(apiKey, region);
     }
@@ -178,6 +178,7 @@ public class AzureSpeechRecognizer implements SpeechProcessor {
     private void listen(SpeechRecognizer rec, SpeechContext context) {
         RecognitionListener recognitionListener =
               new RecognitionListener(context);
+        rec.recognizing.addEventListener(recognitionListener);
         rec.recognized.addEventListener(recognitionListener);
 
         CancellationListener cancellationListener =
@@ -191,7 +192,6 @@ public class AzureSpeechRecognizer implements SpeechProcessor {
                 flush();
             }
 
-            frame.rewind();
             this.buffer.put(frame);
         }
     }

--- a/src/main/java/io/spokestack/spokestack/profile/TFWakewordGoogleASR.java
+++ b/src/main/java/io/spokestack/spokestack/profile/TFWakewordGoogleASR.java
@@ -47,7 +47,7 @@ import java.util.List;
  *      account credentials, used to authenticate with the speech API
  *   </li>
  *   <li>
- *      <b>locale</b> (string): language code for speech recognition
+ *      <b>locale</b> (string): BCP-47 language code for speech recognition
  *   </li>
  * </ul>
  *

--- a/src/test/java/io/spokestack/spokestack/microsoft/AzureSpeechRecognizerTest.java
+++ b/src/test/java/io/spokestack/spokestack/microsoft/AzureSpeechRecognizerTest.java
@@ -52,7 +52,6 @@ public class AzureSpeechRecognizerTest implements OnSpeechEventListener {
     private SpeechRecognitionEventArgs partialRecognitionEvent;
     private SpeechRecognitionEventArgs emptyTextEvent;
     private SpeechRecognitionEventArgs recognitionEvent;
-    private SpeechRecognitionEventArgs timeoutEvent;
     private SpeechRecognitionCanceledEventArgs canceledEvent;
 
     @Before
@@ -99,13 +98,6 @@ public class AzureSpeechRecognizerTest implements OnSpeechEventListener {
         doReturn("test").when(finalResult).getText();
         doReturn(ResultReason.RecognizedSpeech).when(finalResult).getReason();
         when(recognitionEvent.getResult()).thenReturn(finalResult);
-
-        timeoutEvent = PowerMockito.mock(SpeechRecognitionEventArgs.class);
-        SpeechRecognitionResult timeoutResult =
-              mock(SpeechRecognitionResult.class);
-        doReturn("").when(timeoutResult).getText();
-        doReturn(ResultReason.RecognizedSpeech).when(timeoutResult).getReason();
-        when(timeoutEvent.getResult()).thenReturn(timeoutResult);
 
         canceledEvent = PowerMockito.mock(SpeechRecognitionCanceledEventArgs.class);
         doReturn(CancellationReason.Error).when(canceledEvent).getReason();
@@ -184,13 +176,6 @@ public class AzureSpeechRecognizerTest implements OnSpeechEventListener {
         assertEquals("test", context.getTranscript());
         assertEquals(1.0, context.getConfidence());
         assertEquals(SpeechContext.Event.RECOGNIZE, this.event);
-
-        context.reset();
-        new AzureSpeechRecognizer.RecognitionListener(context)
-              .onEvent(mockRecognizer, timeoutEvent);
-        assertEquals("", context.getTranscript());
-        assertEquals(0.0, context.getConfidence());
-        assertEquals(SpeechContext.Event.TIMEOUT, this.event);
 
         this.event = null;
         new AzureSpeechRecognizer.RecognitionListener(context)


### PR DESCRIPTION
I found out during a code review that the Azure ASR component wasn't using a configuration property that it advertised itself as accepting. In testing out that fix, I also discovered we were missing an event listener. I've also adjusted the buffer size to hopefully make the partial results a little snappier and removed the timeout event because Azure seems to like sending empty transcripts after it's already sent (occasionally) complete ones.

In general, the ASR accuracy here isn't what I remember seeing back when the component was first written, but I can get it to work if I speak slowly/clearly enough, and no amount of buffer/stream manipulation on my end has improved performance, so I'm forced to assume that they just have a bad model in production right now or have somehow broken streaming inference.