### PR TITLE
resume idempotence

### DIFF
--- a/src/main/java/io/spokestack/spokestack/SpeechPipeline.java
+++ b/src/main/java/io/spokestack/spokestack/SpeechPipeline.java
@@ -258,8 +258,13 @@ public final class SpeechPipeline implements AutoCloseable {
     /**
      * Resumes a paused speech pipeline, returning the pipeline to a passive
      * listening state.
+     *
+     * Does nothing if the pipeline has not been previously paused.
      */
     public void resume() {
+        if (!this.paused) {
+            return;
+        }
         this.paused = false;
         synchronized (lock) {
             lock.notify();

--- a/src/main/java/io/spokestack/spokestack/SpeechPipeline.java
+++ b/src/main/java/io/spokestack/spokestack/SpeechPipeline.java
@@ -167,12 +167,14 @@ public final class SpeechPipeline implements AutoCloseable {
     }
 
     /**
-     * starts up the speech pipeline.
+     * Starts the speech pipeline. If the pipeline is already running but has
+     * been paused, it will be resumed.
      *
      * @throws Exception on configuration/startup error
      */
     public void start() throws Exception {
         if (this.running) {
+            resume();
             this.context.traceDebug(
                   "attempting to start a running pipeline; ignoring");
             return;

--- a/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
+++ b/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
@@ -223,6 +223,9 @@ public class SpeechPipelineTest implements OnSpeechEventListener {
         Thread.sleep(5);
         assertTrue(FreeInput.counter > frames);
 
+        // resume before pause doesn't cause any hangs
+        pipeline.resume();
+
         // we won't get any more frames if we're paused
         pipeline.pause();
 

--- a/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
+++ b/src/test/java/io/spokestack/spokestack/SpeechPipelineTest.java
@@ -241,6 +241,14 @@ public class SpeechPipelineTest implements OnSpeechEventListener {
         pipeline.resume();
         Thread.sleep(5);
         assertTrue(FreeInput.counter > frames);
+
+        // test that start() also resumes the pipeline
+        pipeline.pause();
+        Thread.sleep(10);
+        frames = FreeInput.counter;
+        pipeline.start();
+        Thread.sleep(5);
+        assertTrue(FreeInput.counter > frames);
     }
 
     @Test


### PR DESCRIPTION
This ensures that calling `resume` on an unpaused pipeline doesn't hang the pipeline thread.

It also makes `start` act like `resume` on a paused pipeline.